### PR TITLE
Update the 'art' command to default to the fist artwork.

### DIFF
--- a/php/commands/art.php
+++ b/php/commands/art.php
@@ -16,7 +16,7 @@ class Art_Command extends Terminus_Command {
    *
    */
   function __invoke( $args, $assoc_args ) {
-    $artwork = array_shift($args);
+    $artwork = array_shift($args) ?: array_keys($this->works, 0);
 
     if (!empty($artwork) && array_key_exists($artwork, $this->works)){
       echo Terminus::colorize("%g".base64_decode($this->works[$artwork])."%n")."\n";


### PR DESCRIPTION
Currently, the 'art' command defaults to showing an error message:

```
$: terminus art
Error: No formula for requested artwork
```

I had to look into the code to tell what artwork was available.  Given that this is the first command in the help, and sounds cool, it would be nice it if worked out of the box.   This defaults to showing the fist.

It could also show a list of the available art, although I'm not sure how easter-eggy we want the unicorn to be (which is a rad ascii unicorn BTW).
