### PR TITLE
AL-1038: Fixes #1697, terminus whoami no longer exits with 1

### DIFF
--- a/src/Commands/Auth/WhoamiCommand.php
+++ b/src/Commands/Auth/WhoamiCommand.php
@@ -34,7 +34,7 @@ class WhoamiCommand extends TerminusCommand
             $user = $this->session()->getUser();
             return new PropertyList($user->fetch()->serialize());
         } else {
-            $this->log()->notice('You are not logged in.');
+            throw new \Exception('You are not logged in.');
         }
     }
 }


### PR DESCRIPTION
The annotated command library really wants to print '[error]' when the exit code is non-zero, for consistency. If that is okay, then the fix is trivial, as shown.

If the desire is to maintain a '[notice]' and still have the exit code be non-zero, then a modification to the annotated command library would be necessary. We could simply omit the '[error]' output when the message is empty. Consistency is probably better, though; it might be odd to have the command appear to finish successfully, but still set a non-zero exit code.