### PR TITLE
List required ext-xml in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.5.38",
+    "ext-xml": "*",
     "composer/semver": "^1.4",
     "consolidation/comments": "^1.0.2",
     "consolidation/filter-via-dot-access-data": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73159373e760344d19f0d07481f66f2e",
+    "content-hash": "c1af0b85156269ffde5f132a55aad87b",
     "packages": [
         {
             "name": "composer/semver",
@@ -2502,9 +2502,9 @@
             "authors": [
                 {
                     "name": "Kitamura Satoshi",
+                    "role": "Original creator",
                     "email": "with.no.parachute@gmail.com",
-                    "homepage": "https://www.facebook.com/satooshi.jp",
-                    "role": "Original creator"
+                    "homepage": "https://www.facebook.com/satooshi.jp"
                 },
                 {
                     "name": "Takashi Matsuo",
@@ -3986,7 +3986,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.38"
+        "php": ">=5.5.38",
+        "ext-xml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
I think it's easy enough for a user's first experience with terminus to go something like:
```
$ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
$ bin/terminus
PHP Fatal error:  Uncaught ReflectionException: Class DOMDocument does not exist in /home/mpantheon/terminus/vendor/consolidation/output-formatters/src/Transformations/DomToArraySimplifier.php:24
```
This PR is one of several possible UX improvements, with just this we get at installation
```
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-xml * is missing from your system. Install or enable PHP's xml extension.
```

We could perhaps also iterate on this to add our own checks in the installer and/or in terminus itself for users of the .phar, but I think this change is fine regardless to make the composer.json more correct.