### PR TITLE
[CORE-71] Use HTTPS when printing site URL (terminus env:view)

### DIFF
--- a/src/Commands/Env/ViewCommand.php
+++ b/src/Commands/Env/ViewCommand.php
@@ -36,7 +36,7 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
         list(, $env) = $this->getUnfrozenSiteEnv($site_env);
 
         $domain = $env->domain();
-        $protocol = 'http';
+        $protocol = 'https';
 
         if ($lock = $env->get('lock')) {
             if ($lock->locked) {

--- a/tests/features/env-view.feature
+++ b/tests/features/env-view.feature
@@ -12,6 +12,6 @@ Feature: Getting an environment's URL
     When I run "terminus env:view [[test_site_name]].dev --print"
     Then I should get:
     """
-    http://dev-[[test_site_name]].onebox.pantheonsite.io/
+    https://dev-[[test_site_name]].onebox.pantheonsite.io/
     """
 

--- a/tests/unit_tests/Commands/Env/ViewCommandTest.php
+++ b/tests/unit_tests/Commands/Env/ViewCommandTest.php
@@ -47,7 +47,7 @@ class ViewCommandTest extends EnvCommandTest
             ->method('get');
 
         $url = $this->command->view('my-site.dev', ['print' => true]);
-        $this->assertEquals('http://dev-my-site.example.com/', $url);
+        $this->assertEquals('https://dev-my-site.example.com/', $url);
     }
 
     /**
@@ -69,7 +69,7 @@ class ViewCommandTest extends EnvCommandTest
             ->method('get');
 
         $url = $this->command->view('my-site.dev', ['print' => true]);
-        $this->assertEquals('http://user:pass@dev-my-site.example.com/', $url);
+        $this->assertEquals('https://user:pass@dev-my-site.example.com/', $url);
     }
 
     /**
@@ -77,7 +77,7 @@ class ViewCommandTest extends EnvCommandTest
      */
     public function testViewOpen()
     {
-        $expected_url = 'http://dev-my-site.example.com/';
+        $expected_url = 'https://dev-my-site.example.com/';
 
         $local_machine_helper = $this->getMockBuilder(LocalMachineHelper::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Since HTTPS everywhere is now on by default, Terminus should return a URL using the `https://` protocol when calling `terminus env:view`.