### PR TITLE
Autocomplete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       # Install without dev components to build a smaller phar
       - run: composer install --no-dev --no-interaction --prefer-dist
       - run: composer phar:install-tools
+      - run: composer global require bamarni/symfony-console-autocomplete
       - run: composer phar:build
       # Re-install with dev components so that we can run phpunit
       - run: composer install --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -36,26 +36,29 @@
     "bin/terminus"
   ],
   "scripts": {
-      "phar:install-tools": [
-        "gem install mime-types -v 2.6.2",
-        "curl -LSs https://box-project.github.io/box2/installer.php | php",
-        "mkdir -p tools",
-        "mv -f box.phar tools/box"
-      ],
-      "phar:build": "env PATH=tools:$PATH box build",
-      "update-class-lists": ["\\Terminus\\UpdateClassLists::update"],
-      "behat": "SHELL_INTERACTIVE=true behat --colors --config tests/config/behat.yml --suite=default",
-      "cbf": "phpcbf --standard=PSR2 -n tests/unit_tests/* bin/terminus src/*",
-      "clover": "phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml",
-      "coveralls": "php vendor/bin/php-coveralls -v -c tests/config/coveralls.yml",
-      "cs": "phpcs --standard=PSR2 --severity=1 -n tests/unit_tests bin/terminus src",
-      "docs": "php scripts/make-docs.php",
-      "lint": "@cs",
-      "phpunit": "SHELL_INTERACTIVE=true phpunit --colors=always  -c tests/config/phpunit.xml.dist --debug",
-      "functional": "phpunit --colors=always -c tests/config/functional.phpunit.xml.dist --debug",
-      "test": "set -ex ; composer cs ; composer phpunit ; composer behat ; composer functional"
+    "phar:install-tools": [
+      "gem install mime-types -v 2.6.2",
+      "curl -LSs https://box-project.github.io/box2/installer.php | php",
+      "mkdir -p tools",
+      "mv -f box.phar tools/box"
+    ],
+    "autocomplete:build": "php scripts/build-autocomplete.php",
+    "phar:build": "env PATH=tools:$PATH box build",
+    "update-class-lists": ["\\Terminus\\UpdateClassLists::update"],
+    "behat": "SHELL_INTERACTIVE=true behat --colors --config tests/config/behat.yml --suite=default",
+    "cbf": "phpcbf --standard=PSR2 -n tests/unit_tests/* bin/terminus src/*",
+    "clover": "phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml",
+    "coveralls": "php vendor/bin/php-coveralls -v -c tests/config/coveralls.yml",
+    "cs": "phpcs --standard=PSR2 --severity=1 -n tests/unit_tests bin/terminus src",
+    "docs": "php scripts/make-docs.php",
+    "lint": "@cs",
+    "phpunit": "SHELL_INTERACTIVE=true phpunit --colors=always  -c tests/config/phpunit.xml.dist --debug",
+    "functional": "phpunit --colors=always -c tests/config/functional.phpunit.xml.dist --debug",
+    "test": "set -ex ; composer cs ; composer phpunit ; composer behat ; composer functional",
+    "post-install-cmd": "php scripts/build-autocomplete.php"
   },
   "require-dev": {
+    "bamarni/symfony-console-autocomplete": "^1.3",
     "behat/behat": "^3.2.2",
     "php-vcr/php-vcr": "^1.4",
     "phpunit/phpunit": "^4.8.36",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73159373e760344d19f0d07481f66f2e",
+    "content-hash": "f5dbc7680a88c2bddb6083b814de70f4",
     "packages": [
         {
             "name": "composer/semver",
@@ -2160,6 +2160,56 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "bamarni/symfony-console-autocomplete",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bamarni/symfony-console-autocomplete.git",
+                "reference": "0fb747e5fdad1f4a028ef42a02bc4a3c4ef8fc12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bamarni/symfony-console-autocomplete/zipball/0fb747e5fdad1f4a028ef42a02bc4a3c4ef8fc12",
+                "reference": "0fb747e5fdad1f4a028ef42a02bc4a3c4ef8fc12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "symfony/console": "^2.5|^3|^4",
+                "symfony/process": "^2.5|^3|^4"
+            },
+            "require-dev": {
+                "symfony/console": "2.8.*"
+            },
+            "bin": [
+                "bin/symfony-autocomplete"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Bamarni\\Symfony\\Console\\Autocomplete\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bilal Amarni",
+                    "email": "bilal.amarni@gmail.com",
+                    "role": "Lead developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "RQuadling@gmail.com",
+                    "role": "Contributing developer"
+                }
+            ],
+            "description": "Shell completion for Symfony Console based scripts",
+            "time": "2019-08-02T15:22:55+00:00"
+        },
         {
             "name": "beberlei/assert",
             "version": "v2.9.9",

--- a/scripts/build-autocomplete.php
+++ b/scripts/build-autocomplete.php
@@ -1,0 +1,14 @@
+<?php
+// are dev requirements installed?
+if ( file_exists('vendor/bin/symfony-autocomplete') ) {
+    $autocomplete = shell_exec('vendor/bin/symfony-autocomplete bin/terminus');
+    // d($autocomplete);
+    file_put_contents('assets/autocomplete.txt', $autocomplete);
+} elseif ( strlen(shell_exec('which symfony-autocomplete')) > 0 ) {
+    // global install?
+    $autocomplete = shell_exec('symfony-autocomplete bin/terminus');
+    file_put_contents('assets/autocomplete.txt', $autocomplete);
+} else {
+    echo "Please install dev dependencies, or run composer global require bamarni/symfony-console-autocomplete";
+    exit(1);
+}

--- a/src/Commands/AutocompleteCommand.php
+++ b/src/Commands/AutocompleteCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pantheon\Terminus\Commands;
+
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
+use Pantheon\Terminus\Helpers\LocalMachineHelper;
+
+/**
+ * Class AutocompleteCommand
+ * @package Pantheon\Terminus\Commands
+ */
+class AutocompleteCommand extends TerminusCommand
+{
+    
+    /**
+     * Displays Terminus Autocomplete config
+     *
+     * @command autocomplete
+     *
+     * @usage Returns the shell autocomplete config.
+     */
+    public function autocomplete() 
+    {
+        return $this->retrieveList();
+    }
+
+    /**
+     * Return the filename.
+     *
+     * @return string
+     */
+    protected function getFilename()
+    {
+        return $this->config->get('assets_dir') . "/autocomplete.txt";
+    }
+
+    /**
+     * Retrieve the contents of the autocomplete file.
+     *
+     * @return string
+     * @throws TerminusNotFoundException
+     */
+    protected function retrieveList()
+    {
+        $filename = $this->getFilename();
+        $local_machine_helper = $this->getContainer()->get(LocalMachineHelper::class);
+        if (!$local_machine_helper->getFilesystem()->exists($filename)) {
+            throw new TerminusNotFoundException(
+                'Please generate the autocomplete script using the `composer autocomplete:build` command.'
+            );
+        }
+        return $local_machine_helper->readFile($filename);
+    }
+}

--- a/src/Commands/AutocompleteCommand.php
+++ b/src/Commands/AutocompleteCommand.php
@@ -19,7 +19,7 @@ class AutocompleteCommand extends TerminusCommand
      *
      * @usage Returns the shell autocomplete config.
      */
-    public function autocomplete() 
+    public function autocomplete()
     {
         return $this->retrieveList();
     }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -125,6 +125,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
             'Pantheon\\Terminus\\Hooks\\Authorizer',
             'Pantheon\\Terminus\\Hooks\\SiteEnvLookup',
             'Pantheon\\Terminus\\Commands\\AliasesCommand',
+            'Pantheon\\Terminus\\Commands\\AutocompleteCommand',
             'Pantheon\\Terminus\\Commands\\ArtCommand',
             'Pantheon\\Terminus\\Commands\\Auth\\LoginCommand',
             'Pantheon\\Terminus\\Commands\\Auth\\LogoutCommand',


### PR DESCRIPTION
Adds a feature for #1595 

Provides an autocomplete feature compatible with zsh and bash-completion. Allows for easy tab completion in supported shells.

I may have over complicated this, but in order to minimize the distribution size I've adopted a strategy for caching the autocomplete script. This allows us to only generate the autocomplete script when building the phar file, since we don't need the script to be dynamic. I suppose one downside of this is that it may not pickup plugins.

Very open to additional thoughts and improvements. Currently requires that you set the following in your `.zshrc` file: 
```bash
eval "$(terminus autocomplete)"
```

![terminus-autocomplete](https://user-images.githubusercontent.com/171515/66649357-f4ecf780-ebfb-11e9-9501-fed747678f66.gif)
