### PR TITLE
[CORE-1593] apply updates for IC-enabled sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## MASTER
+### Changed
+- `upstream:updates:apply` now applies Composer changes in addition to upstream changes. (#2089)
+
 ## 2.4.1 - 2020-09-02
 ### Changed
 - The `DrushRCEditor` class has been renamed to `DrushRcClass`. (#2083)

--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -49,7 +49,7 @@ class ApplyCommand extends UpdatesCommand
         if ($count || $composerCount) {
             $prefix = sprintf("Applying %d upstream update(s)", $count);
             if ($composerCount) {
-                $prefix .= sprintf(" and %d composer update(s)", $composerCount);
+                $prefix .= " and any composer update(s)";
             }
             $this->log()->notice(
                 '{prefix} to the {env} environment of {site_id}...',

--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -49,7 +49,7 @@ class ApplyCommand extends UpdatesCommand
         if ($count || $composerCount) {
             $prefix = sprintf("Applying %d upstream update(s)", $count);
             if ($composerCount) {
-                $prefix .= sprintf(" and %d composer updates", $composerCount);
+                $prefix .= sprintf(" and %d composer update(s)", $composerCount);
             }
             $this->log()->notice(
                 '{prefix} to the {env} environment of {site_id}...',

--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -42,18 +42,27 @@ class ApplyCommand extends UpdatesCommand
         }
 
         $updates = $this->getUpstreamUpdatesLog($env);
-        $count = count($updates);
-        if ($count) {
-            $this->log()->notice(
-                'Applying {count} upstream update(s) to the {env} environment of {site_id}...',
-                ['count' => $count, 'env' => $env->id, 'site_id' => $site->get('name'),]
-            );
+        $composerUpdates = $this->getComposerUpdatesLog($env);
 
+        $count = count($updates);
+        $composerCount = count($composerUpdates);
+        if ($count || $composerCount) {
+            $prefix = sprintf("Applying %d upstream update(s)", $count);
+            if ($composerCount) {
+                $prefix .= sprintf(" and %d composer updates", $composerCount);
+            }
+            $this->log()->notice(
+                '{prefix} to the {env} environment of {site_id}...',
+                [
+                    'prefix' => $prefix,
+                    'env' => $env->id,
+                    'site_id' => $site->get('name'),
+                ]
+            );
             $workflow = $env->applyUpstreamUpdates(
                 isset($options['updatedb']) ? $options['updatedb'] : false,
                 isset($options['accept-upstream']) ? $options['accept-upstream'] : false
             );
-
             $this->processWorkflow($workflow);
             $this->log()->notice($workflow->getMessage());
         } else {

--- a/src/Commands/Upstream/Updates/UpdatesCommand.php
+++ b/src/Commands/Upstream/Updates/UpdatesCommand.php
@@ -42,4 +42,34 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
         $updates = $this->getUpstreamUpdates($env);
         return property_exists($updates, 'update_log') ? (array)$updates->update_log : [];
     }
+
+    /**
+     * Get the list of composer dependency updates for a site environment
+     *
+     * @param Environment $env
+     * @return array The list of updates
+     * @throws TerminusException
+     */
+    protected function getComposerUpdatesLog($env)
+    {
+        // Check if the site is IC-enabled.
+        if (empty($env->isBuildStepEnabled())) {
+            return [];
+        }
+        $updates = $env->getUpstreamStatus()->getComposerUpdates();
+        if (empty($updates)) {
+            return [];
+        }
+        $deps = [];
+        if (!empty($updates->added_dependencies)) {
+            $deps = array_merge($deps, $updates->added_dependencies);
+        }
+        if (!empty($updates->updated_dependencies)) {
+            $deps = array_merge($deps, $updates->updated_dependencies);
+        }
+        if (!empty($updates->removed_dependencies)) {
+            $deps = array_merge($deps, $updates->removed_dependencies);
+        }
+        return $deps;
+    }
 }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -889,4 +889,26 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         $response = (array)$this->request()->request($path, ['method' => 'get',]);
         return $response['data']->$setting;
     }
+
+    /**
+     * Checks if the environment has the build step enabled by looking
+     * at the environment variables defined in pantheon.yml.
+     *
+     * @return bool
+     */
+    public function isBuildStepEnabled()
+    {
+        $path = sprintf(
+            'sites/%s/environments/%s/variables',
+            $this->getSite()->id,
+            $this->id
+        );
+        $options = ['method' => 'get',];
+        $response = $this->request()->request($path, $options);
+        if (empty($response['data']) || !isset($response['data']->BUILD_STEP)) {
+            return false;
+        }
+        return $response['data']->BUILD_STEP;
+    }
+
 }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -910,5 +910,4 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         }
         return $response['data']->BUILD_STEP;
     }
-
 }

--- a/src/Models/UpstreamStatus.php
+++ b/src/Models/UpstreamStatus.php
@@ -20,6 +20,13 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
      */
     protected $updates = null;
 
+     /**
+      * Stores composer dependency updates.
+      *
+      * @var object|null
+      */
+    protected $composerUpdates = null;
+
     public function __construct($attributes, array $options = [])
     {
         parent::__construct($attributes, $options);
@@ -53,6 +60,22 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
             )['data'];
         }
         return $this->updates;
+    }
+
+    /**
+     * Retrives composer dependecy updates
+     *
+     * @return object
+     */
+    public function getComposerUpdates()
+    {
+        if ($this->composerUpdates === null) {
+            $env = $this->getEnvironment();
+            $this->composerUpdates = $this->request()->request(
+                "sites/{$env->getSite()->id}/environments/{$env->id}/build/updates"
+            )['data'];
+        }
+        return $this->composerUpdates;
     }
 
     /**

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -125,7 +125,7 @@ class ApplyCommandTest extends UpdatesCommandTest
             ->method('log')
             ->with(
                 $this->equalTo('notice'),
-                $this->equalTo('Applying {count} upstream update(s) to the {env} environment of {site_id}...'),
+                $this->equalTo('{prefix} to the {env} environment of {site_id}...'),
                 $this->equalTo(['count' => 2, 'env' => 'dev', 'site_id' => 'my-site'])
             );
 

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -126,7 +126,7 @@ class ApplyCommandTest extends UpdatesCommandTest
             ->with(
                 $this->equalTo('notice'),
                 $this->equalTo('{prefix} to the {env} environment of {site_id}...'),
-                $this->equalTo(['count' => 2, 'env' => 'dev', 'site_id' => 'my-site'])
+                $this->equalTo(['prefix' => 'Applying 2 upstream update(s)', 'env' => 'dev', 'site_id' => 'my-site'])
             );
 
         $this->logger->expects($this->at(1))

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -230,7 +230,10 @@ class ApplyCommandTest extends UpdatesCommandTest
                 $this->equalTo('notice'),
                 $this->equalTo('Applied upstream updates to "dev"')
             );
-        $out = $this->command->applyUpstreamUpdates('my-composer-site', ['accept-upstream' => true, 'updatedb' => true,]);
+        $out = $this->command->applyUpstreamUpdates('my-composer-site', [
+            'accept-upstream' => true, 
+            'updatedb' => true,
+        ]);
         $this->assertNull($out);
     }
 }

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -231,7 +231,7 @@ class ApplyCommandTest extends UpdatesCommandTest
                 $this->equalTo('Applied upstream updates to "dev"')
             );
         $out = $this->command->applyUpstreamUpdates('my-composer-site', [
-            'accept-upstream' => true, 
+            'accept-upstream' => true,
             'updatedb' => true,
         ]);
         $this->assertNull($out);

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -219,7 +219,7 @@ class ApplyCommandTest extends UpdatesCommandTest
                 $this->equalTo('notice'),
                 $this->equalTo('{prefix} to the {env} environment of {site_id}...'),
                 $this->equalTo([
-                    'prefix' => 'Applying 0 upstream update(s) and 2 composer update(s)',
+                    'prefix' => 'Applying 0 upstream update(s) and any composer update(s)',
                     'env' => 'dev',
                     'site_id' => 'my-composer-site',
                 ])


### PR DESCRIPTION
**Problem description:**
IC-enabled sites can have composer dependency updates without having any actual upstream updates. These show up on the dashboard as shown in the screenshot below. The dashboard allows the possibility to apply these and terminus should do the same.

**Proposed solution:**
Do what the dashboard does. If the site is IC-enabled and if there are composer updates detected by calling the `sites/{site_id}/environments/{env_id}/build/updates` api, allow terminus to invoke the workflow which applies the updates.

<img width="863" alt="Screen Shot 2020-09-08 at 5 05 56 PM" src="https://user-images.githubusercontent.com/2629630/92487548-0963b680-f1f6-11ea-8474-01e507d7d1d6.png">