### PR TITLE
Building a lock:sync command

### DIFF
--- a/src/Commands/Lock/SyncCommand.php
+++ b/src/Commands/Lock/SyncCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Lock;
+
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Commands\StructuredListTrait;
+use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+
+/**
+ * Class SyncCommand
+ * @package Pantheon\Terminus\Commands\Lock
+ */
+class SyncCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+    use WorkflowProcessingTrait;
+
+    /**
+     * Displays HTTP basic authentication status and configuration for the environment.
+     *
+     * @authorize
+     *
+     * @command lock:sync
+     *
+     * @param string $site_env Origin site & environment in the format `site-name.env`
+     * @param string $target_env Target environment
+     *
+     * @usage <site>.<env> <target_env> Synchronizes the lock settings from <site>'s <env> environment to <target_env>.
+     */
+    public function sync($site_env, $target_env)
+    {
+        /** @var \Pantheon\Terminus\Models\Site $site */
+        /** @var \Pantheon\Terminus\Models\Environment $source_env */
+        list($site, $source_env) = $this->getSiteEnv($site_env);
+
+        if ($source_env->id === $target_env) {
+            $this->log()->notice('The sync has been skipped because the source and target environments are the same.');
+            return;
+        }
+
+        $target = $site->getEnvironments()->get($target_env);
+
+        /** @var \Pantheon\Terminus\Models\Lock $source_lock */
+        $source_lock = $source_env->getLock();
+        $target_lock = $target->getLock();
+
+        if ($source_lock->serialize() == $target_lock->serialize()) {
+            $this->log()->notice('The source and target environment locks already match.');
+            return;
+        }
+
+        if (!$source_lock->isLocked()) {
+            $this->processWorkflow($target_lock->disable());
+        }
+        else {
+            $this->processWorkflow($target_lock->enable([
+                'username' => $source_lock->get('username'),
+                'password' => $source_lock->get('password'),
+            ]));
+        }
+
+        $this->log()->notice(
+            '{site}.{env} lock has been synced to {target_env}.',
+            ['site' => $site->get('name'), 'env' => $source_env->id, 'target_env' => $target->id,]
+        );
+    }
+}

--- a/src/Commands/Lock/SyncCommand.php
+++ b/src/Commands/Lock/SyncCommand.php
@@ -54,8 +54,7 @@ class SyncCommand extends TerminusCommand implements SiteAwareInterface
 
         if (!$source_lock->isLocked()) {
             $this->processWorkflow($target_lock->disable());
-        }
-        else {
+        } else {
             $this->processWorkflow($target_lock->enable([
                 'username' => $source_lock->get('username'),
                 'password' => $source_lock->get('password'),

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -173,6 +173,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
             'Pantheon\\Terminus\\Commands\\Lock\\DisableCommand',
             'Pantheon\\Terminus\\Commands\\Lock\\EnableCommand',
             'Pantheon\\Terminus\\Commands\\Lock\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\SyncCommand',
             'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteAllCommand',
             'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteCommand',
             'Pantheon\\Terminus\\Commands\\MachineToken\\ListCommand',


### PR DESCRIPTION
I would like this command from a CI environment point of view. If creating a multidev for a pull request, it makes sense that you can sync the lock from the source environment also, otherwise you have a security issue. i.e. `dev, test and live' are locked but any multidev built by build tools is public.

I considered extending `multidev:create` with `--with-lock` or similar but thought a general command to do this would be more useful.