### PR TITLE
Fix usage of symfony/process to use fromShellCommandline.

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -204,11 +204,10 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
      */
     protected function getProcess($cmd)
     {
-        $process = NULL;
+        $process = null;
         if (is_string($cmd)) {
             $process = Process::fromShellCommandline($cmd);
-        }
-        elseif (is_array($cmd)) {
+        } elseif (is_array($cmd)) {
             $process = new Process($cmd);
         }
         if ($process) {

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -199,7 +199,7 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
     /**
      * Returns a set-up process object.
      *
-     * @param string $cmd The command to execute
+     * @param string|array $cmd The command to execute
      * @return Process
      */
     protected function getProcess($cmd)
@@ -210,10 +210,11 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
         } elseif (is_array($cmd)) {
             $process = new Process($cmd);
         }
-        if ($process) {
-            $config = $this->getConfig();
-            $process->setTimeout($config->get('timeout'));
+        if (!$process) {
+            throw new \InvalidArgumentException('$cmd should be a string or an array.');
         }
+        $config = $this->getConfig();
+        $process->setTimeout($config->get('timeout'));
         return $process;
     }
 }

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -204,12 +204,17 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
      */
     protected function getProcess($cmd)
     {
+        $process = NULL;
         if (is_string($cmd)) {
-            $cmd = [ $cmd ];
+            $process = Process::fromShellCommandline($cmd);
         }
-        $process = new Process($cmd);
-        $config = $this->getConfig();
-        $process->setTimeout($config->get('timeout'));
+        elseif (is_array($cmd)) {
+            $process = new Process($cmd);
+        }
+        if ($process) {
+            $config = $this->getConfig();
+            $process->setTimeout($config->get('timeout'));
+        }
         return $process;
     }
 }


### PR DESCRIPTION
symfony/process constructor starting on 3.4 needs an array for the command to execute.

In order to pass fully created cmd line, fromShellCommandline function should be used; otherwise, the command won't work as expected with weird errors like:

```
sh: line 0: exec <cmd> not found
```
