### PR TITLE
Remove warning for the next Terminus pre-release.

### DIFF
--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -14,15 +14,6 @@ use Pantheon\Terminus\Models\TerminusModel;
 class LoginCommand extends TerminusCommand
 {
 
-    public static $HELP_TEXT = [
-        "*******************************************************************************",
-        "* THIS IS AN EARLY VERSION OF TERMINUS 3.0. NOT ALL THE COMMANDS ARE WORKING  *",
-        "* AND IT'S NOT 100% COMPATIBLE WITH PHP 8 BUT WE'RE GETTING THERE.            *",
-        "* If you find a bug you think needs to be addressed, please add the bug to    *",
-        "* terminus issue queue: https://github.com/pantheon-systems/terminus/issues   *",
-        "*******************************************************************************",
-    ];
-
     /**
      * Logs in a user to Pantheon.
      *
@@ -91,12 +82,6 @@ class LoginCommand extends TerminusCommand
         /** @var $token \Pantheon\Terminus\Models\SavedToken */
         $token->logIn();
         $this->log()->notice('Logged in via machine token.');
-
-        if (static::$HELP_TEXT) {
-            $this->log()->notice(
-                PHP_EOL . join(PHP_EOL, static::$HELP_TEXT)
-            );
-        }
     }
 
     /**


### PR DESCRIPTION
I think we have enough test coverage that it is reasonable to simply remove this warning now.