### PR TITLE
CMS-31 linux packaging

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -109,6 +109,64 @@ jobs:
           revision: ${{github.sha}}
           formula: terminus
 
+  package_linux:
+    runs-on: ubuntu-latest
+    name: Package .deb Release
+    container:
+      image: quay.io/pantheon-public/php-ci:v7.4
+    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+    needs: [ 'functional_tests', 'behat_tests' ]
+    steps:
+      - name: Download repo content from artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: full-workspace
+      - name: Download terminus.phar as artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: terminus-phar
+      - name: Full Composer Install
+        run: composer install
+      - name: Prepare needed folder and fix permissions
+        run: mkdir -p ~/.terminus/cache/tokens && chmod +x ./terminus
+      - name: Passegers, gather ye packages
+        run: composer bundle:linux
+      - name: Save terminus deb as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: terminus-deb
+          path: ./*.deb
+          if-no-files-found: error
+
+  publish_linux:
+    runs-on: ubuntu-latest
+    name: Publish .deb Release
+    strategy:
+      matrix:
+        # Add needed repositories in the form of <package_name>/<distro>/<version>.
+        repository:
+          - 'terminus/debian/buster'
+          - 'terminus/debian/bullseye'
+          - 'terminus/ubuntu/bionic'
+          - 'terminus/ubuntu/focal'
+          - 'terminus/ubuntu/groovy'
+          - 'terminus/ubuntu/hirsute'
+    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+    needs: [ 'package_linux' ]
+    steps:
+      - name: Download terminus deb as artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: terminus-deb
+      - uses: docker://lpenz/ghaction-packagecloud:v0.2
+        with:
+          user: stovak
+          repository: ${{ matrix.repository }}
+          path: |
+            *.deb
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
   # # NOT CURRENTLY USED
   # behat_tests:
   #   runs-on: ubuntu-latest
@@ -158,62 +216,3 @@ jobs:
   #     - name: Update tap with new release
   #       run: brew bump-formula-pr --url=${{ steps.tagged.outputs.url }} --no-browse --no-audit --commit stovak/terminus/terminus
 
-  # # NOT CURRENTLY USED
-  # package_linux:
-  #   runs-on: ubuntu-latest
-  #   name: Package .deb Release
-  #   container:
-  #     image: quay.io/pantheon-public/php-ci:v7.4
-  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-  #   needs: [ 'functional_tests', 'behat_tests' ]
-  #   steps:
-  #     - name: Download repo content from artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: full-workspace
-  #     - name: Download terminus.phar as artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: terminus-phar
-  #     - name: Full Composer Install
-  #       run: composer install
-  #     - name: Prepare needed folder and fix permissions
-  #       run: mkdir -p ~/.terminus/cache/tokens && chmod +x ./terminus
-  #     - name: Passegers, gather ye packages
-  #       run: composer bundle:linux
-  #     - name: Save terminus deb as artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: terminus-deb
-  #         path: ./*.deb
-  #         if-no-files-found: error
-
-  # # NOT CURRENTLY USED
-  # publish_linux:
-  #   runs-on: ubuntu-latest
-  #   name: Publish .deb Release
-  #   strategy:
-  #     matrix:
-  #       # Add needed repositories in the form of <package_name>/<distro>/<version>.
-  #       repository:
-  #         - 'terminus/debian/buster'
-  #         - 'terminus/debian/bullseye'
-  #         - 'terminus/ubuntu/bionic'
-  #         - 'terminus/ubuntu/focal'
-  #         - 'terminus/ubuntu/groovy'
-  #         - 'terminus/ubuntu/hirsute'
-  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-  #   needs: [ 'package_linux' ]
-  #   steps:
-  #     - name: Download terminus deb as artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: terminus-deb
-  #     - uses: docker://lpenz/ghaction-packagecloud:v0.2
-  #       with:
-  #         user: stovak
-  #         repository: ${{ matrix.repository }}
-  #         files: |
-  #           *.deb
-  #       env:
-  #         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -115,7 +115,7 @@ jobs:
     container:
       image: quay.io/pantheon-public/php-ci:v7.4
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-    needs: [ 'functional_tests', 'behat_tests' ]
+    needs: [ release ]
     steps:
       - name: Download repo content from artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -147,10 +147,12 @@ jobs:
         repository:
           - 'terminus/debian/buster'
           - 'terminus/debian/bullseye'
+          - 'terminus/debian/bookworm'
           - 'terminus/ubuntu/bionic'
           - 'terminus/ubuntu/focal'
           - 'terminus/ubuntu/groovy'
           - 'terminus/ubuntu/hirsute'
+          - 'terminus/ubuntu/impish'
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
     needs: [ 'package_linux' ]
     steps:


### PR DESCRIPTION
This has been [tested in a fork](https://github.com/namespacebrian/terminus/blob/3.x-linux-package/.github/workflows/3x.yml#L162) ([GH action success](https://github.com/namespacebrian/terminus/runs/3954189490?check_suite_focus=true#step:4:16)).  A small change was required for the packagecloud.io submission to work: changing `files` to `path` in the `lpenz/ghaction-packagecloud` action.  Packages published by the automation can be seen here: [https://packagecloud.io/brianweaver/terminus](https://packagecloud.io/brianweaver/terminus).

The automation as currently set up uses the `stovak` user to publish to the (currently empty) [stovak/terminus repository](https://packagecloud.io/stovak/terminus).  I think we would need to reach out via #engineering to create some kind of service user & api token; when requesting access for myself via Spoke, I was directed to ask in the #engineering slack channel.