### PR TITLE
Add Redis clear

### DIFF
--- a/src/Commands/Env/ClearCacheCommand.php
+++ b/src/Commands/Env/ClearCacheCommand.php
@@ -27,18 +27,21 @@ class ClearCacheCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases env:cc
      *
      * @param string $site_env Site & environment in the format `site-name.env`
+     * @param array $options
+     * @option bool $framework_cache [true|false] Clear the CMS cache
+     * @option bool $varnish_cache [true|false] Clear the edge cache
      *
      * @usage <site>.<env> Clears caches for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusProcessException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    public function clearCache($site_env)
+    public function clearCache($site_env, $options = ['framework_cache' => true, 'varnish_cache' => false,])
     {
         $this->requireSiteIsNotFrozen($site_env);
         $env = $this->getEnv($site_env);
 
-        $this->processWorkflow($env->clearCache());
+        $this->processWorkflow($env->clearCache($options));
         $this->log()->notice(
             'Caches cleared on {env}.',
             ['env' => $env->getName()]

--- a/src/Commands/Redis/ClearCommand.php
+++ b/src/Commands/Redis/ClearCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Redis;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
+use Pantheon\Terminus\Exceptions\TerminusProcessException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+
+/**
+ * Class ClearCommand
+ * @package Pantheon\Terminus\Commands\Redis
+ */
+class ClearCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+    use WorkflowProcessingTrait;
+
+    /**
+     * Clear the Redis cache for a site environment.
+     *
+     * @authorize
+     *
+     * @command redis:clear
+     *
+     * @param string $site_id Site name
+     *
+     * @usage <site> Clear the Redis cache for <site>.
+     * 
+     * @throws \Pantheon\Terminus\Exceptions\TerminusProcessException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function clear($site_env)
+    {
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite();
+        $env = $this->getEnv($site_env);
+
+        $workflow = $site->getRedis()->clear($env);
+        $this->processWorkflow($workflow);
+        $this->log()->notice($workflow->getMessage());
+    }
+}

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -110,9 +110,9 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
      *
      * @return Workflow
      */
-    public function clearCache()
+    public function clearCache(array $options = [])
     {
-        return $this->getWorkflows()->create('clear_cache', ['params' => ['framework_cache' => true,],]);
+        return $this->getWorkflows()->create('clear_cache', ['params' => $options,]);
     }
 
     /**

--- a/src/Models/Redis.php
+++ b/src/Models/Redis.php
@@ -16,7 +16,7 @@ class Redis extends AddOnModel
      * @param Environment $env An object representing the environment on which to clear the Redis cache
      * @return Workflow
      */
-    public function clear($env)
+    public function clear(Environment $env)
     {
         // @Todo: Change this when the env model conversion is merged
         return $env->getWorkflows()->create('clear_redis_cache');


### PR DESCRIPTION
There is a Redis cache clear option available in the platform, but it is not yet exposed as a command within Terminus. This will add a new `redis:clear` command that runs on an environment.

In addition, this also adds Varnish as an option when clearing the cache as right now we only clear the framework cache (ie, `drush cr` or `wp cache flush`).