### PR TITLE
Remove 'alpha' command prefix alias(es)

### DIFF
--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -26,7 +26,7 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
      * @authorize
      *
      * @command aliases
-     * @aliases drush:aliases alpha:aliases
+     * @aliases drush:aliases
      *
      * @option boolean $print Print aliases only (Drush 8 format)
      * @option string $location Path and filename for php aliases.

--- a/src/Commands/Env/MetricsCommand.php
+++ b/src/Commands/Env/MetricsCommand.php
@@ -47,7 +47,7 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
      * @authorize
      *
      * @command env:metrics
-     * @aliases metrics,alpha:env:metrics,alpha:metrics
+     * @aliases metrics
      *
      * @field-labels
      *     datetime: Period


### PR DESCRIPTION
This PR prunes two command aliases using an `alpha:` prefix.