### PR TITLE
local:clone - adding "--branch" option to specify cloning a particular multidev branch

### DIFF
--- a/src/Commands/Local/CloneCommand.php
+++ b/src/Commands/Local/CloneCommand.php
@@ -37,10 +37,11 @@ class CloneCommand extends TerminusCommand implements SiteAwareInterface, Config
      *
      * @option site_dir Custom directory for the local copy. By default, the site name is used
      * @option override Override the local copy if exists
+     * @option branch The branch to clone. Default is master
      *
      * @usage <site> Clone's a local copy into "$HOME/pantheon-local-copies"
      */
-    public function clone(string $site_id, array $options = ['site_dir' => null, 'override' => null]): string
+    public function clone(string $site_id, array $options = ['site_dir' => null, 'override' => null, 'branch' => null]): string
     {
         $site = $this->getSiteById($site_id);
         $env = $site->getEnvironments()->get('dev');
@@ -48,8 +49,10 @@ class CloneCommand extends TerminusCommand implements SiteAwareInterface, Config
         $gitUrl = $env->connectionInfo()['git_url'] ?? null;
         $localCopyDir = $site->getLocalCopyDir($options['site_dir'] ?? null);
 
-        // @todo This value should come from somewhere else.
         $devBranch = 'master';
+        if ( ! empty( $options['branch'] ) ) {
+            $devBranch = $options['branch'];
+        }
 
         try {
             /** @var \Pantheon\Terminus\Helpers\LocalMachineHelper $localMachineHelper */

--- a/src/Commands/Local/CloneCommand.php
+++ b/src/Commands/Local/CloneCommand.php
@@ -41,18 +41,14 @@ class CloneCommand extends TerminusCommand implements SiteAwareInterface, Config
      *
      * @usage <site> Clone's a local copy into "$HOME/pantheon-local-copies"
      */
-    public function clone(string $site_id, array $options = ['site_dir' => null, 'override' => null, 'branch' => null]): string
+    public function clone(string $site_id, array $options = ['site_dir' => null, 'override' => null, 'branch' => 'master']): string
     {
         $site = $this->getSiteById($site_id);
         $env = $site->getEnvironments()->get('dev');
 
         $gitUrl = $env->connectionInfo()['git_url'] ?? null;
         $localCopyDir = $site->getLocalCopyDir($options['site_dir'] ?? null);
-
-        $devBranch = 'master';
-        if ( ! empty( $options['branch'] ) ) {
-            $devBranch = $options['branch'];
-        }
+        $devBranch = $options['branch'];
 
         try {
             /** @var \Pantheon\Terminus\Helpers\LocalMachineHelper $localMachineHelper */


### PR DESCRIPTION
I'm working on a GitHub Actions workflow where I want to clone the Pantheon repository and sync it with a corresponding GitHub repository. When working with multidev branches, it would be useful to be able to clone the Pantheon repository with the desired multidev branch directly, rather than having to add a step to checkout the desired branch.

I saw in the code that this was a @\todo item anyway; here's the code to accomplish that.

Cloning still defaults to the "master" branch if no optional --branch flag is supplied.