### PR TITLE
ArtCommand: art:list incorrect capitalization fixed

### DIFF
--- a/src/Commands/ArtCommand.php
+++ b/src/Commands/ArtCommand.php
@@ -39,7 +39,7 @@ class ArtCommand extends TerminusCommand
             'description' => 'A wonderful unicorn',
         ],
         'wordpress' => [
-            'name' => 'wordPress',
+            'name' => 'wordpress',
             'description' => 'The WordPress logo',
         ],
     ];


### PR DESCRIPTION
`art:list` outputs name `wordPress`, but entering `terminus art wordPress` results in an error. Should be all lowercase.