### PR TITLE
[DEVX-3831] Check for attempts at using old versions of PHP

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -1,4 +1,4 @@
-name: Terminus 3.x
+name: Terminus 4.x
 on:
   push:
   schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ A PHAR file must also be built before running tests.
 
 The functional test files are in the `tests/Functional` directory.
 
-The Terminus 3.x functional tests can be run via:
+The Terminus 4.x functional tests can be run via:
 
   ```bash
   cd /install/location/terminus

--- a/bin/terminus
+++ b/bin/terminus
@@ -12,10 +12,10 @@
 // Unset memory limit
 ini_set('memory_limit', -1);
 
-if (version_compare(PHP_VERSION, '7.4.0', '<') === true) {
+if (version_compare(PHP_VERSION, '8.2.0', '<') === true) {
     fwrite(STDERR, "\n");
     fwrite(STDERR, 'Sorry, your PHP version (' . PHP_VERSION . ') is no longer supported.' . "\n");
-    fwrite(STDERR, 'Upgrade to PHP 7.4 or newer to use Terminus 3. For PHP versions prior to 7.4, downgrade to Terminus 2.x.' . "\n\n");
+    fwrite(STDERR, 'Upgrade to PHP 8.2 or newer to use Terminus 4. For PHP versions prior to 8.2, downgrade to Terminus 3.x.' . "\n\n");
     fwrite(STDERR, 'For more information, see https://pantheon.io/docs/terminus/updates#php-version-compatibility-matrix' . "\n\n");
     exit(1);
 }

--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -79,7 +79,7 @@ class InstallCommand extends PluginBaseCommand
             return;
         }
 
-        // Get installed Terminus 3 plugins.
+        // Get installed Terminus 4 plugins.
         $plugins = $this->getPluginProjects();
         $t3projects = array_filter(
             array_map(


### PR DESCRIPTION
Fail fast with an error if someone attempts to use a version of PHP that is too old.

Also fixes a couple of Terminus 3 vs Terminus 4 references.