### PR TITLE
More metadata in request headers

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -464,11 +464,20 @@ class Request implements
     private function userAgent()
     {
         $config = $this->getConfig();
+
+        $environment_info = [
+            'php_version' => $config->get('version'),
+            'script' => $config->get('php_version'),
+            'os' => PHP_OS,
+        ];
+
+        if (getenv('CI')) {
+            $environment_info['ci'] = '1',
+        }
+
         return sprintf(
-            'Terminus/%s (php_version=%s&script=%s)',
-            $config->get('version'),
-            $config->get('php_version'),
-            $config->get('script')
+            'Terminus/%s (%s)',
+            explode('&', $environment_info)
         );
     }
 


### PR DESCRIPTION
Add info about the client OS and whether they are on a CI environment to each request's user agent string.

This is not a breaking change, but it would be good to figure out what else we want, and get it in before 4.0.0.