### PR TITLE
[DEVX-3831] Allow PHP binary to be selected via an environment variable.

### DIFF
--- a/bin/terminus
+++ b/bin/terminus
@@ -1,81 +1,50 @@
-#!/usr/bin/env php
-<?php
+#!/usr/bin/env sh
 
-/**
- * This script runs Terminus. It does the following:
- *   - Includes the Composer autoload file
- *   - Starts a container with the input, output, application, and configuration objects
- *   - Starts a runner instance and runs the command
- *   - Exits with a status code
- */
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-// Unset memory limit
-ini_set('memory_limit', -1);
+# If we can find a .env file next to the `terminus` binary, source it.
+# TODO: Is this a reasonable location? Where else should we look?
+# Should we make the filename more specific, e.g. `.terminus-env`?
+if [ -f "$SCRIPTPATH/.env" ]; then
+  source "$SCRIPTPATH/.env"
+fi
 
-if (version_compare(PHP_VERSION, '8.2.0', '<') === true) {
-    fwrite(STDERR, "\n");
-    fwrite(STDERR, 'Sorry, your PHP version (' . PHP_VERSION . ') is no longer supported.' . "\n");
-    fwrite(STDERR, 'Upgrade to PHP 8.2 or newer to use Terminus 4. For PHP versions prior to 8.2, downgrade to Terminus 3.x.' . "\n\n");
-    fwrite(STDERR, 'For more information, see https://pantheon.io/docs/terminus/updates#php-version-compatibility-matrix' . "\n\n");
-    exit(1);
-}
+# One good fallback location is in the Terminus config directory.
+# Note that we already have $HOME/.terminus/config.yml, but I
+# don't think we should parse that here.
+if [ -f "$HOME/.terminus/.env" ]; then
+  source "$HOME/.terminus/.env"
+fi
 
-if (!getenv('TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP') && version_compare(PHP_VERSION, '8.5.0', '>=') === true) {
-    fwrite(STDERR, "\n");
-    fwrite(STDERR, 'PHP 8.5+ is not supported by this version of Terminus.' . "\n");
-    fwrite(STDERR, 'Check for new versions at https://github.com/pantheon-systems/terminus/releases' . "\n");
-    fwrite(STDERR, "\n");
-    fwrite(STDERR, 'Set environment variable TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP to try continuing anyway.' . "\n");
-    fwrite(STDERR, "Stopping.\n\n");
-    exit(1);
-}
+# The logic below is ideal for scripts that are distributed
+# in `vendor/bin`. We might benefit if we decide to support
+# `terminus create-project pantheon-systems/terminus` as an
+# installation method. If we decide aginst this, we could
+# remove "$COMPOSER_RUNTIME_BIN_DIR" checks.
+if [ -z "$COMPOSER_RUNTIME_BIN_DIR" ]; then
+  # This branch is for the development of Drush itself.
+  # @see https://stackoverflow.com/questions/4774054
+  TERMINUS_EXECUTABLE="$SCRIPTPATH/terminus.php"
+else
+  TERMINUS_EXECUTABLE="$COMPOSER_RUNTIME_BIN_DIR/terminus.php"
+fi
 
-// This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
-// which is run after every call to composer update.
-$terminusPluginsDependenciesVersion = '51e2c517dd';
+# If we can't find `terminus.php` next to `terminus`,
+# look for `terminus.php` in the same directory.
+if [ ! -f "$TERMINUS_EXECUTABLE" ]; then
+  TERMINUS_EXECUTABLE="$SCRIPTPATH/terminus.phar"
+fi
 
-// Cannot use $_SERVER superglobal since that's empty during phpunit testing
-// getenv('HOME') isn't set on Windows and generates a Notice.
-$home = @getenv('HOME');
-if (!empty($home)) {
-    // home should never end with a trailing slash.
-    $home = rtrim($home, '/');
-}
+# If there is no `terminus.phar` nearby, check for one
+# in the $PATH.
+if [ ! -f "$TERMINUS_EXECUTABLE" ]; then
+  TERMINUS_EXECUTABLE="terminus.phar"
+fi
 
-if (empty($home) && !empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
-    // home on windows
-    $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
-    // If HOMEPATH is a root directory the path can end with a slash. Make sure
-    // that doesn't happen.
-    $home = rtrim($home, '\\/');
-    @putenv("HOME={$home}");
-}
+# Use the PHP binary indicated by $TERMINUS_PHP, or use
+# the one in the $PATH if $TERMINUS_PHP is not set.
+PHP="${TERMINUS_PHP=php}"
 
-$pharPath = \Phar::running(true);
-if ($pharPath) {
-    include_once("$pharPath/vendor/autoload.php");
-} elseif (file_exists($path = __DIR__ . '/../vendor/autoload.php')
-        || file_exists($path = __DIR__ . '/../../autoload.php')
-        || file_exists($path = __DIR__ . '/../../../autoload.php')
-) {
-    include_once($path);
-} else {
-    throw new \Exception('Could not locate autoload.php');
-}
-
-use Pantheon\Terminus\Terminus;
-
-$home_tokens_folder = '.terminus' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'tokens';
-
-$tokens_dir = $home . DIRECTORY_SEPARATOR . $home_tokens_folder;
-if (!is_dir($tokens_dir)) {
-    mkdir(
-            $tokens_dir,
-            0700,
-            true
-    );
-}
-
-$terminus = Terminus::factory($terminusPluginsDependenciesVersion);
-$status_code = $terminus->run();
-exit($status_code);
+# Run Terminus with the selected version of PHP, passing
+# through all parameters.
+exec "$TERMINUS_PHP" "$TERMINUS_EXECUTABLE" "$@"

--- a/bin/terminus.php
+++ b/bin/terminus.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This script runs Terminus. It does the following:
+ *   - Includes the Composer autoload file
+ *   - Starts a container with the input, output, application, and configuration objects
+ *   - Starts a runner instance and runs the command
+ *   - Exits with a status code
+ */
+
+// Unset memory limit
+ini_set('memory_limit', -1);
+
+if (version_compare(PHP_VERSION, '8.2.0', '<') === true) {
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, 'Sorry, your PHP version (' . PHP_VERSION . ') is no longer supported.' . "\n");
+    fwrite(STDERR, 'Upgrade to PHP 8.2 or newer to use Terminus 4. For PHP versions prior to 8.2, downgrade to Terminus 3.x.' . "\n\n");
+    fwrite(STDERR, 'For more information, see https://pantheon.io/docs/terminus/updates#php-version-compatibility-matrix' . "\n\n");
+    exit(1);
+}
+
+if (!getenv('TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP') && version_compare(PHP_VERSION, '8.5.0', '>=') === true) {
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, 'PHP 8.5+ is not supported by this version of Terminus.' . "\n");
+    fwrite(STDERR, 'Check for new versions at https://github.com/pantheon-systems/terminus/releases' . "\n");
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, 'Set environment variable TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP to try continuing anyway.' . "\n");
+    fwrite(STDERR, "Stopping.\n\n");
+    exit(1);
+}
+
+// This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
+// which is run after every call to composer update.
+$terminusPluginsDependenciesVersion = '51e2c517dd';
+
+// Cannot use $_SERVER superglobal since that's empty during phpunit testing
+// getenv('HOME') isn't set on Windows and generates a Notice.
+$home = @getenv('HOME');
+if (!empty($home)) {
+    // home should never end with a trailing slash.
+    $home = rtrim($home, '/');
+}
+
+if (empty($home) && !empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
+    // home on windows
+    $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
+    // If HOMEPATH is a root directory the path can end with a slash. Make sure
+    // that doesn't happen.
+    $home = rtrim($home, '\\/');
+    @putenv("HOME={$home}");
+}
+
+$pharPath = \Phar::running(true);
+if ($pharPath) {
+    include_once("$pharPath/vendor/autoload.php");
+} elseif (file_exists($path = __DIR__ . '/../vendor/autoload.php')
+        || file_exists($path = __DIR__ . '/../../autoload.php')
+        || file_exists($path = __DIR__ . '/../../../autoload.php')
+) {
+    include_once($path);
+} else {
+    throw new \Exception('Could not locate autoload.php');
+}
+
+use Pantheon\Terminus\Terminus;
+
+$home_tokens_folder = '.terminus' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'tokens';
+
+$tokens_dir = $home . DIRECTORY_SEPARATOR . $home_tokens_folder;
+if (!is_dir($tokens_dir)) {
+    mkdir(
+            $tokens_dir,
+            0700,
+            true
+    );
+}
+
+$terminus = Terminus::factory($terminusPluginsDependenciesVersion);
+$status_code = $terminus->run();
+exit($status_code);

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
     ]
   },
   "bin": [
+    "bin/terminus.php",
     "bin/terminus"
   ],
   "scripts": {


### PR DESCRIPTION
Create a bash wrapper that allows users to select a specific PHP version via an environment variable.

For users who install the `terminus.phar` binary by the existing documented approach, there is no change in behavior; the old way continues to work, but does not allow the PHP binary to be selected (only the one in the $PATH may be used).

For users who install the new `terminus` script in their $PATH, and also put `terminus.phar` in their $PATH (without renaming it), the following behavior is now supported:

```
$ php --version
PHP 7.4.33 (cli) (built: Nov 22 2024 10:43:27) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
$ terminus --version

Sorry, your PHP version (7.4.33) is no longer supported.
Upgrade to PHP 8.2 or newer to use Terminus 4. For PHP versions prior to 8.2, downgrade to Terminus 3.x.

For more information, see https://pantheon.io/docs/terminus/updates#php-version-compatibility-matrix
$ export TERMINUS_PHP=/opt/homebrew/Cellar/php@8.3/8.3.14/bin/php
$ $TERMINUS_PHP --version
PHP 8.3.14 (cli) (built: Nov 19 2024 15:14:23) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.14, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.14, Copyright (c), by Zend Technologies
$ terminus --version
Terminus 4.0.0-dev
```