### PR TITLE
Set SSH Verbose mode to match Terminus

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -372,7 +372,13 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
     {
         $sftp = $this->environment->sftpConnectionInfo();
         $command = $this->getConfig()->get('ssh_command');
-
+        if ($this->output()->isDebug()) {
+            $command .= ' -vvv';
+        } elseif ($this->output()->isVeryVerbose()) {
+            $command .= ' -vv';
+        } elseif ($this->output()->isVerbose()) {
+            $command .= ' -v';
+        }
         return vsprintf(
             '%s -T %s@%s -p %s -o "StrictHostKeyChecking=no" -o "AddressFamily inet"',
             [$command, $sftp['username'], $this->lookupHostViaAlternateNameserver($sftp['host']), $sftp['port']]


### PR DESCRIPTION
When troubleshooting connection issues with Terminus commands that require SSH (drush, wp cli) there can be problems at the machine level that need troubleshooting. 

This PR sets the SSH command to use the same verbosity level as Terminus is running with. 