### PR TITLE
Make site label available to site:list and org:site:list commands

### DIFF
--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -138,6 +138,19 @@ class Sites extends APICollection implements SessionAwareInterface
     }
 
     /**
+    * Filters the members of this collection by their label.
+    *
+    * @param string $regex
+    *   Non-delimited PHP regex to filter site names by
+    *
+    * @return Sites
+    */
+    public function filterByLabel($regex = '(.*)')
+    {
+        return $this->filterByRegex('label', $regex);
+    }
+
+    /**
      * Filters an array of sites by the plan name.
      *
      * @param string $plan_name

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -28,6 +28,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @field-labels
      *     name: Name
+     *     label: Label
      *     id: ID
      *     plan_name: Plan
      *     framework: Framework
@@ -35,6 +36,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     created: Created
      *     tags: Tags
      *     frozen: Is Frozen?
+     * @default-fields name,id,plan_name,framework,owner,created,tags,frozen
      * @return RowsOfFields
      *
      * @param string $organization Organization name, label, or ID

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -23,6 +23,7 @@ class ListCommand extends SiteCommand
      *
      * @field-labels
      *     name: Name
+     *     label: Label
      *     id: ID
      *     plan_name: Plan
      *     framework: Framework


### PR DESCRIPTION
This PR fixes #1968 and does two things:
1. Makes the site label available to `site:list` and `org:site:list` commands when using the `--field`/`--fields` options
2. Adds the ability to filter by site label using the `--filter` option: `--filter='label*=foo'`

`org:site:list` did not have default fields so I set them to keep the default output the same.

Thanks!