### PR TITLE
Disable scheduled nightly tests

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -1,8 +1,6 @@
 name: Terminus 3.x
 on:
   push:
-  schedule:
-    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       functional_tests_group:


### PR DESCRIPTION
This testing is covered by QA's nightly smoke tests and these scheduled tests put unnecessary load on the system.