### PR TITLE
Retry logic was already in environment wake logic

### DIFF
--- a/src/Commands/Env/WakeCommand.php
+++ b/src/Commands/Env/WakeCommand.php
@@ -38,28 +38,10 @@ class WakeCommand extends TerminusCommand implements SiteAwareInterface
         'delay' => 3,
     ])
     {
-        $attempt = 1;
         $this->requireSiteIsNotFrozen($site_env);
         $env = $this->getEnv($site_env);
 
-        while ($attempt <= $options['retry']) {
-            $wakeStatus = $env->wake();
-            if (empty($wakeStatus['success'])) {
-                $this->log()->notice('{target} is not awake (attempt {attempt}/{max})...', [
-                    'target' => $site_env,
-                    'attempt' => $attempt,
-                    'max' => $options['retry'],
-                ]);
-                // If there is any attempt remaining, sleep for the delay period.
-                if ($attempt <= $options['retry'] - 1) {
-                    $this->log()->notice('Sleeping for {delay} seconds...', ['delay' => $options['delay']]);
-                    sleep($options['delay']);
-                }
-                $attempt++;
-                continue;
-            }
-            break;
-        }
+        $wakeStatus = $env->wake($options['retry'], $options['delay']);
 
         // @TODO: Move the exceptions up the chain to the `wake` function. (One env is ported over).
         if (empty($wakeStatus['success'])) {


### PR DESCRIPTION
Environment wake function already had retry logic in it with options that weren't being passed from the `env:wake` command. This PR passes those flags and correctly retries.

Old behavior:
```
./bin/terminus env:wake 1b4929f3-580f-4dc8-9603-7106a7a7a61d.dev --retry 10
 [error]  Failed to wake the site after 3 attempts. 
```

New behavior:
```
./bin/terminus env:wake 1b4929f3-580f-4dc8-9603-7106a7a7a61d.dev --retry 10
 [error]  Failed to wake the site after 10 attempts. 
```