### PR TITLE
[Site-5160] Add php_runtime_generation version to env:info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 4.0.2-dev
 
+### Added
+
+- Added PHP Runtime Generation version to `env:info` command output (#2714)
+
 ## 4.0.1 - 2025-05-19
 
 ### Fixed

--- a/src/Commands/Env/InfoCommand.php
+++ b/src/Commands/Env/InfoCommand.php
@@ -36,6 +36,7 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     connection_mode: Connection Mode
      *     php_version: PHP Version
      *     drush_version: Drush Version
+     *     php_runtime_generation: PHP Runtime Generation
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @return \Consolidation\OutputFormatters\StructuredData\PropertyList
@@ -67,6 +68,7 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
             unset($properties['drush_version']);
             unset($properties['php_version']);
             unset($properties['locked']);
+            unset($properties['php_runtime_generation']);
         }
         return new PropertyList($properties);
     }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -690,7 +690,7 @@ class Environment extends TerminusModel implements
      */
     public function getPHPRuntimeGeneration()
     {
-        return $this->settings('php_runtime_generation');
+         return $this->settings('appserver_runtime')->php_runtime_generation;
     }
 
     /**

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -684,6 +684,16 @@ class Environment extends TerminusModel implements
     }
 
     /**
+     * Gets the PHP runtime generation of this environment
+     *
+     * @return string
+     */
+    public function getPHPRuntimeGeneration()
+    {
+        return $this->settings('php_runtime_generation');
+    }
+
+    /**
      * @return UpstreamStatus
      */
     public function getUpstreamStatus()
@@ -947,6 +957,7 @@ class Environment extends TerminusModel implements
             'initialized' => $this->isInitialized(),
             'connection_mode' => $this->get('connection_mode'),
             'php_version' => $this->getPHPVersion(),
+            'php_runtime_generation' => $this->getPHPRuntimeGeneration(),
         ];
     }
 

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -310,6 +310,11 @@ class EnvCommandsTest extends TerminusTestBase
             $envInfo,
             'Environment info should have "php_version" field.'
         );
+        $this->assertArrayHasKey(
+            'php_runtime_generation',
+            $envInfo,
+            'Environment info should have "php_runtime_generation" field.'
+        );
     }
 
     /**


### PR DESCRIPTION
The terminus env:info command  will outputs the PHP Runtime Generation version.

Tested this PR on production site.

<img width="1025" height="348" alt="Screenshot 2025-09-03 at 4 26 21 PM" src="https://github.com/user-attachments/assets/b9acb848-83a9-4f9e-9f15-f438afd79733" />




https://getpantheon.atlassian.net/browse/SITE-5160



