### PR TITLE
Address PHP exception on `local:commitAndPush`

### DIFF
--- a/src/Commands/Local/CommitAndPushCommand.php
+++ b/src/Commands/Local/CommitAndPushCommand.php
@@ -38,11 +38,11 @@ class CommitAndPushCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site Site
      *
      * @usage <site> Clone's a local copy into "$HOME/pantheon-local-copies"
-     *@return string
+     * @return void
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
      */
-    public function commitAndPushCommand($site): string
+    public function commitAndPushCommand($site): void
     {
         $siteData = $site;
         if (!$siteData instanceof Site) {


### PR DESCRIPTION
When running `local:commitAndPush`, Terminus throws an exception because `commitAndPush` expects to return a string, but the function actually returns a `void` because it lacks a `return` statement.

This exception breaks our CI pipeline because it throws on both successful and unsuccessful runs of `commitAndPush`, and suppressing the error would end up hiding legitimate errors.