### PR TITLE
[minor] add php runtime generation to env:list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-- Add "PHP Runtime Generation (php_runtime_generation) to the `env:list` command (#2729)
+- Add "PHP Runtime Generation" (php_runtime_generation) to the `env:list` command (#2729)
 
 ## 4.0.3 - 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 4.0.4-dev
 
+### Added
+
+- Add "PHP Runtime Generation (php_runtime_generation) to the `env:list` command (#2729)
+
 ## 4.0.3 - 2025-09-11
 
 ### Added

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -36,7 +36,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     initialized: Initialized
      *     php_runtime_generation: PHP Runtime Generation
      * @default-fields id,created,domain,connection_mode,locked,initialized
-     
+
     * @return RowsOfFields
      *
      * @param string $site_id Site name

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -34,6 +34,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     connection_mode: Connection Mode
      *     locked: Locked
      *     initialized: Initialized
+     *     php_runtime_generation: PHP Runtime Generation
      * @return RowsOfFields
      *
      * @param string $site_id Site name

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -35,7 +35,9 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     locked: Locked
      *     initialized: Initialized
      *     php_runtime_generation: PHP Runtime Generation
-     * @return RowsOfFields
+     * @default-fields id,created,domain,connection_mode,locked,initialized
+     
+    * @return RowsOfFields
      *
      * @param string $site_id Site name
      *

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -690,7 +690,7 @@ class Environment extends TerminusModel implements
      */
     public function getPHPRuntimeGeneration()
     {
-         return $this->settings('appserver_runtime')->php_runtime_generation;
+        return $this->settings('appserver_runtime')->php_runtime_generation;
     }
 
     /**

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -455,6 +455,11 @@ class EnvCommandsTest extends TerminusTestBase
             $env,
             'An environment should have "initialized" field.'
         );
+        $this->assertArrayHasKey(
+            'php_runtime_generation',
+            $env,
+            'An environment should have "php_runtime_generation" field.'
+        );
     }
 
     /**

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -455,10 +455,32 @@ class EnvCommandsTest extends TerminusTestBase
             $env,
             'An environment should have "initialized" field.'
         );
+    }
+
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Env\ListCommand
+     *
+     * @group env
+     * @group short
+     */
+    public function testListCommandWithPHPRuntimeGeneration()
+    {
+        $envs = $this->terminusJsonResponse(
+            sprintf('env:list %s --fields=id,php_runtime_generation', $this->getSiteName())
+        );
+        $this->assertIsArray($envs);
+        $env = array_shift($envs);
+
+        $this->assertArrayHasKey(
+            'id',
+            $env,
+            'An environment should have "id" field.'
+        );
         $this->assertArrayHasKey(
             'php_runtime_generation',
             $env,
-            'An environment should have "php_runtime_generation" field.'
+            'An environment should have "php_runtime_generation" field when explicitly requested.'
         );
     }
 


### PR DESCRIPTION
## Summary
- Add php_runtime_generation field label to env:list command to expose this field in the output. Field is optional.
- Add test coverage for php_runtime_generation field in env:list functional tests
- Fix indentation in Environment.php getPHPRuntimeGeneration method

## Background
This addresses issue #2720 by adding the `php_runtime_generation` field to the `env:list` command output. The underlying data was already available in the Environment model's serialize() method, but the field label was missing from the ListCommand, preventing it from being displayed in the output.

## Changes
1. **src/Commands/Env/ListCommand.php**: Added `php_runtime_generation: PHP Runtime Generation` to the @field-labels annotation
2. **tests/Functional/EnvCommandsTest.php**: Added test assertion to verify the `php_runtime_generation` field is present in env:list output
3. **src/Models/Environment.php**: Fixed indentation in getPHPRuntimeGeneration method

## Test plan
- [x] Verify field label is properly added to ListCommand
- [x] Add test coverage for the new field in functional tests
- [x] Run existing test suite to ensure no regressions
- [x] Test env:list command output includes php_runtime_generation field

```
% ./bin/terminus env:list $MY_SITE --fields=id,php_runtime_generation
 ----------- ------------------------
  ID          PHP Runtime Generation
 ----------- ------------------------
  test        1
  newenv      2
  autopilot   2
  live        1
  dev         2
 ----------- ------------------------
./bin/terminus env:list $MY_SITE --fields="ID","PHP Runtime Generation"
 ----------- ------------------------
  ID          PHP Runtime Generation
 ----------- ------------------------
  test        1
  newenv      2
  autopilot   2
  live        1
  dev         2
 ----------- ------------------------
```

Resolves #2720