### PR TITLE
[minor] add php version to env:list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-- Add "PHP Runtime Generation" (php_runtime_generation) to the `env:list` command (#2729)
+- Add "PHP Runtime Generation" (php_runtime_generation) and "PHP Version" (php_version) to the `env:list` command (#2729, #2732)
 
 ## 4.0.3 - 2025-09-11
 

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -34,6 +34,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     connection_mode: Connection Mode
      *     locked: Locked
      *     initialized: Initialized
+     *     php_version: PHP Version
      *     php_runtime_generation: PHP Runtime Generation
      * @default-fields id,created,domain,connection_mode,locked,initialized
 

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -486,6 +486,33 @@ class EnvCommandsTest extends TerminusTestBase
 
     /**
      * @test
+     * @covers \Pantheon\Terminus\Commands\Env\ListCommand
+     *
+     * @group env
+     * @group short
+     */
+    public function testListCommandWithPHPVersion()
+    {
+        $envs = $this->terminusJsonResponse(
+            sprintf('env:list %s --fields=id,php_version', $this->getSiteName())
+        );
+        $this->assertIsArray($envs);
+        $env = array_shift($envs);
+
+        $this->assertArrayHasKey(
+            'id',
+            $env,
+            'An environment should have "id" field.'
+        );
+        $this->assertArrayHasKey(
+            'php_version',
+            $env,
+            'An environment should have "php_version" field when explicitly requested.'
+        );
+    }
+
+    /**
+     * @test
      * @covers \Pantheon\Terminus\Commands\Env\ViewCommand
      *
      * @group env


### PR DESCRIPTION
Right after #2729 a case came up where I wished I had php_version for all environments. Adds "PHP Version" (php_version) as an optional field to env:list.
```
% ./bin/terminus env:list $MY_SITE --fields=id,php_version
 ----------- -------------
  ID          PHP Version
 ----------- -------------
  live        8.4
  test        8.4
  autopilot   8.4
  dev         8.4
  wpclidemo   8.2
  mymdev      8.2
 ----------- -------------
```