### PR TITLE
DEVX-3831: Create new Dockerfile to run Terminus in isolated environment

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -49,6 +49,17 @@ jobs:
           path: terminus.phar
           if-no-files-found: error
 
+  build_docker_image:
+    runs-on: ubuntu-latest
+    name: Build Docker image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build . -t terminus
+      - name: Run built Docker image
+        run: docker run terminus art
+
   functional:
     runs-on: ${{ matrix.operating-system }}
     name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@
 FROM php:8.2-cli AS build
 
 # Install dependencies for building PHAR
-RUN apt-get update && apt-get install -y git unzip wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        git \
+        unzip \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
@@ -23,6 +28,12 @@ RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
 FROM php:8.2-cli-alpine
+
+# Create a non-root user and group
+RUN addgroup -S terminus && adduser -S terminus -G terminus
+
+# Switch to non-root user
+USER terminus
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
+# --- Composer Layer ---
+FROM composer:2 AS composer
+
 # --- Build Layer ---
-FROM php:8.2-cli AS build
+FROM php:8.3-cli-alpine AS build
 
 # Install dependencies for building PHAR
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        git \
-        unzip \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash git wget
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
 
@@ -27,7 +25,10 @@ RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O 
 RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
-FROM php:8.2-cli-alpine
+FROM php:8.3-cli-alpine
+
+# Install Git, Unzip, and Wget dependencies
+RUN apk add --no-cache git openssh
 
 # Create a non-root user and group
 RUN addgroup -S terminus && adduser -S terminus -G terminus
@@ -36,9 +37,6 @@ RUN addgroup -S terminus && adduser -S terminus -G terminus
 USER terminus
 
 WORKDIR /app
-
-# Copy Git
-RUN apk add --no-cache git unzip wget
 
 # Copy Composer from build layer
 COPY --from=build /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM composer:2 AS composer
 
 # --- Build Layer ---
-FROM php:8.3-cli-alpine AS build
+FROM php:8.4-cli-alpine AS build
 
 # Install dependencies for building PHAR
 RUN apk add --no-cache bash git wget
@@ -19,13 +19,13 @@ COPY . .
 RUN composer install --no-interaction --no-dev --optimize-autoloader
 
 # Install Box for PHAR building
-RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
+RUN wget https://github.com/box-project/box/releases/download/4.6.7/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
 
 # Build PHAR file
 RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
-FROM php:8.3-cli-alpine
+FROM php:8.4-cli-alpine
 
 # Install Git, Unzip, and Wget dependencies
 RUN apk add --no-cache git openssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# --- Build Layer ---
+FROM php:8.2-cli AS build
+
+# Install dependencies for building PHAR
+RUN apt-get update && apt-get install -y git unzip wget && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+# Copy source files
+COPY . .
+
+# Install PHP dependencies
+RUN composer install --no-interaction --no-dev --optimize-autoloader
+
+# Install Box for PHAR building
+RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
+
+# Build PHAR file
+RUN ./scripts/phar_build.sh
+
+# --- Runtime Layer ---
+FROM php:8.2-cli-alpine
+
+WORKDIR /app
+
+# Copy Git
+RUN apk add --no-cache git unzip wget
+
+# Copy Composer from build layer
+COPY --from=build /usr/bin/composer /usr/bin/composer
+
+# Copy built PHAR from build layer
+COPY --from=build /app/terminus.phar /app/terminus.phar
+
+# Set entrypoint to run the PHAR
+ENTRYPOINT ["/app/terminus.phar"]

--- a/README.md
+++ b/README.md
@@ -74,3 +74,28 @@ chmod +x terminus
 ./terminus self:update
 sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 ```
+
+### Standalone Docker container
+
+Terminus can also be built and run as a Docker container, rather than relying on system version of PHP and other dependencies.
+
+```bash
+docker build . -f Dockerfile -t terminus
+```
+
+In order to store configuration and install plugins, Terminus requires a persistent data directory. If you only plan to run Terminus via Docker, please run the following command to create a Docker data volume:
+
+```bash
+docker volume create terminus --ignore
+```
+
+The container can be run of 2 different ways:
+
+- Directly using `docker` (or `podman`, etc.):
+
+        docker run -tv terminus:/root/.terminus terminus:latest art
+
+- Alternatively implement an alias in your local environment:
+
+        alias terminus="docker run -tv ~/.terminus:/root/.terminus terminus:latest"
+        terminus art

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The container can be run of 2 different ways:
 
 - Directly using `docker` (or `podman`, etc.):
 
-        docker run -tv terminus:/root/.terminus terminus:latest art
+        docker run -tv terminus:/root/.terminus terminus:latest self:info
 
 - Alternatively implement an alias in your local environment:
 
         alias terminus="docker run -tv ~/.terminus:/root/.terminus terminus:latest"
-        terminus art
+        terminus self:info

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 Terminus can also be built and run as a Docker container, rather than relying on system version of PHP and other dependencies.
 
 ```bash
-docker build . -f Dockerfile -t terminus
+docker build . -t terminus
 ```
 
 In order to store configuration and install plugins, Terminus requires a persistent data directory. If you only plan to run Terminus via Docker, please run the following command to create a Docker data volume:


### PR DESCRIPTION
For customers that do not (or prefer not) to have a local PHP environment like potentially Next.js developers, an alternative installation method via Docker avoids any need for local setup.

- Install all necessary dependencies into Docker build and run layers
- Using PHP 8.4 for Docker image
- Add README instructions to utilize standalone Docker container method with notes on using Docker volume for config persistence

Specifically, the local flow is -

```bash
docker build . -t terminus
docker volume create terminus --ignore
docker run -tv terminus:/root/.terminus terminus:latest self:info
```