### PR TITLE
feat: publish Terminus as a Docker image on release [DEVX-7424]

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -49,6 +49,17 @@ jobs:
           path: terminus.phar
           if-no-files-found: error
 
+  build_docker_image:
+    runs-on: ubuntu-latest
+    name: Build Docker image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build . -t terminus
+      - name: Run built Docker image
+        run: docker run terminus art
+
   functional:
     runs-on: ${{ matrix.operating-system }}
     name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -187,7 +187,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    needs: [ functional ]
+    needs: [ release ]
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
     env:
       REGISTRY: ghcr.io

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -62,6 +62,32 @@ jobs:
       - name: Run built Docker image
         run: docker run terminus art
 
+  test_docker_plugin:
+    runs-on: ubuntu-latest
+    name: Test Docker image with a local plugin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Build Docker image
+        run: docker build . -t terminus
+      - name: Prepare a local plugin and a writable ~/.terminus mount
+        run: |
+          git clone --depth 1 https://github.com/pantheon-systems/terminus-plugin-example.git "${RUNNER_TEMP}/plugin-src"
+          mkdir -p "${RUNNER_TEMP}/terminus"
+          chmod 0777 "${RUNNER_TEMP}/terminus"
+      - name: Install the plugin from the mounted local file path
+        run: |
+          docker run --rm \
+            -v "${RUNNER_TEMP}/terminus":/home/terminus/.terminus \
+            -v "${RUNNER_TEMP}/plugin-src":/plugin-src \
+            terminus self:plugin:install /plugin-src
+      - name: Run the installed plugin from the persisted ~/.terminus
+        run: |
+          docker run --rm \
+            -v "${RUNNER_TEMP}/terminus":/home/terminus/.terminus \
+            -v "${RUNNER_TEMP}/plugin-src":/plugin-src \
+            terminus hello 2>&1 | tee /dev/stderr | grep -q 'Hello, World!'
+
   functional:
     runs-on: ${{ matrix.operating-system }}
     name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
@@ -152,6 +178,52 @@ jobs:
           files: terminus.phar
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+
+  publish_docker_image:
+    runs-on: ubuntu-latest
+    name: Publish Docker image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    needs: [ functional ]
+    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5.6.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4 # v6.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   package_macos:
     runs-on: macos-latest

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -51,18 +51,7 @@ jobs:
           path: terminus.phar
           if-no-files-found: error
 
-  build_docker_image:
-    runs-on: ubuntu-latest
-    name: Build Docker image
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - name: Build Docker image
-        run: docker build . -t terminus
-      - name: Run built Docker image
-        run: docker run terminus art
-
-  test_docker_plugin:
+  test_docker_image:
     runs-on: ubuntu-latest
     name: Test Docker image with a local plugin
     steps:

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -56,7 +56,7 @@ jobs:
     name: Build Docker image
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Build Docker image
         run: docker build . -t terminus
       - name: Run built Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,22 +27,29 @@ RUN ./scripts/phar_build.sh
 # --- Runtime Layer ---
 FROM php:8.4-cli-alpine
 
-# Install Git, Unzip, and Wget dependencies
-RUN apk add --no-cache git openssh
+# Install Git, SSH, and Unzip dependencies
+RUN apk add --no-cache git openssh unzip
 
-# Create a non-root user and group
-RUN addgroup -S terminus && adduser -S terminus -G terminus
+# Create a non-root user and group. UID/GID 1000 matches the typical first
+# local user, so a bind-mounted ~/.terminus stays writable inside the container.
+RUN addgroup -g 1000 terminus \
+ && adduser -u 1000 -G terminus -h /home/terminus -D terminus
 
-# Switch to non-root user
-USER terminus
-
-WORKDIR /app
+# Terminus reads its configuration, plugins, and cache from $HOME/.terminus.
+ENV HOME=/home/terminus
+RUN mkdir -p /home/terminus/.terminus \
+ && chown -R terminus:terminus /home/terminus
 
 # Copy Composer from build layer
 COPY --from=build /usr/bin/composer /usr/bin/composer
 
 # Copy built PHAR from build layer
 COPY --from=build /app/terminus.phar /app/terminus.phar
+
+# Switch to the non-root user
+USER terminus
+
+WORKDIR /home/terminus
 
 # Set entrypoint to run the PHAR
 ENTRYPOINT ["/app/terminus.phar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@
 FROM php:8.2-cli AS build
 
 # Install dependencies for building PHAR
-RUN apt-get update && apt-get install -y git unzip wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        git \
+        unzip \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
@@ -23,6 +28,12 @@ RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
 FROM php:8.2-cli-alpine
+
+# Create a non-root user and group
+RUN addgroup -S terminus && adduser -S terminus -G terminus
+
+# Switch to non-root user
+USER terminus
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
+# --- Composer Layer ---
+FROM composer:2 AS composer
+
 # --- Build Layer ---
-FROM php:8.2-cli AS build
+FROM php:8.3-cli-alpine AS build
 
 # Install dependencies for building PHAR
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        git \
-        unzip \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash git wget
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
 
@@ -27,7 +25,10 @@ RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O 
 RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
-FROM php:8.2-cli-alpine
+FROM php:8.3-cli-alpine
+
+# Install Git, Unzip, and Wget dependencies
+RUN apk add --no-cache git openssh
 
 # Create a non-root user and group
 RUN addgroup -S terminus && adduser -S terminus -G terminus
@@ -36,9 +37,6 @@ RUN addgroup -S terminus && adduser -S terminus -G terminus
 USER terminus
 
 WORKDIR /app
-
-# Copy Git
-RUN apk add --no-cache git unzip wget
 
 # Copy Composer from build layer
 COPY --from=build /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM composer:2 AS composer
 
 # --- Build Layer ---
-FROM php:8.3-cli-alpine AS build
+FROM php:8.4-cli-alpine AS build
 
 # Install dependencies for building PHAR
 RUN apk add --no-cache bash git wget
@@ -19,13 +19,13 @@ COPY . .
 RUN composer install --no-interaction --no-dev --optimize-autoloader
 
 # Install Box for PHAR building
-RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
+RUN wget https://github.com/box-project/box/releases/download/4.6.7/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
 
 # Build PHAR file
 RUN ./scripts/phar_build.sh
 
 # --- Runtime Layer ---
-FROM php:8.3-cli-alpine
+FROM php:8.4-cli-alpine
 
 # Install Git, Unzip, and Wget dependencies
 RUN apk add --no-cache git openssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# --- Build Layer ---
+FROM php:8.2-cli AS build
+
+# Install dependencies for building PHAR
+RUN apt-get update && apt-get install -y git unzip wget && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+# Copy source files
+COPY . .
+
+# Install PHP dependencies
+RUN composer install --no-interaction --no-dev --optimize-autoloader
+
+# Install Box for PHAR building
+RUN wget https://github.com/box-project/box/releases/download/4.5.1/box.phar -O /usr/local/bin/box && chmod +x /usr/local/bin/box
+
+# Build PHAR file
+RUN ./scripts/phar_build.sh
+
+# --- Runtime Layer ---
+FROM php:8.2-cli-alpine
+
+WORKDIR /app
+
+# Copy Git
+RUN apk add --no-cache git unzip wget
+
+# Copy Composer from build layer
+COPY --from=build /usr/bin/composer /usr/bin/composer
+
+# Copy built PHAR from build layer
+COPY --from=build /app/terminus.phar /app/terminus.phar
+
+# Set entrypoint to run the PHAR
+ENTRYPOINT ["/app/terminus.phar"]

--- a/README.md
+++ b/README.md
@@ -77,25 +77,32 @@ sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 
 ### Standalone Docker container
 
-Terminus can also be built and run as a Docker container, rather than relying on system version of PHP and other dependencies.
+As an alternative to the standalone PHAR above, Terminus is also published as a Docker image, so it can run without a local PHP environment or other system dependencies. The image runs as a non-root `terminus` user.
+
+Each tagged release is published to the [GitHub Container Registry](https://github.com/pantheon-systems/terminus/pkgs/container/terminus). Pull the tag you want — a specific version, a major version, or `latest`:
+
+```bash
+docker pull ghcr.io/pantheon-systems/terminus:latest
+```
+
+Terminus stores your machine token, configuration, and installed plugins in `~/.terminus`. Bind-mount your local `~/.terminus` directory into the container so that data is written to — and persists on — your local filesystem:
+
+```bash
+mkdir -p ~/.terminus
+docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest self:info
+```
+
+For convenience, add an alias to your shell. Plugins you install are written to your local `~/.terminus` and remain available on subsequent runs:
+
+```bash
+alias terminus="docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest"
+terminus auth:login --machine-token=<token>
+terminus self:plugin:install <Packagist project or local path>
+```
+
+Alternatively, build the image from a local checkout of this repository instead of pulling it:
 
 ```bash
 docker build . -t terminus
+docker run --rm -tv ~/.terminus:/home/terminus/.terminus terminus self:info
 ```
-
-In order to store configuration and install plugins, Terminus requires a persistent data directory. If you only plan to run Terminus via Docker, please run the following command to create a Docker data volume:
-
-```bash
-docker volume create terminus --ignore
-```
-
-The container can be run of 2 different ways:
-
-- Directly using `docker` (or `podman`, etc.):
-
-        docker run -tv terminus:/root/.terminus terminus:latest self:info
-
-- Alternatively implement an alias in your local environment:
-
-        alias terminus="docker run -tv ~/.terminus:/root/.terminus terminus:latest"
-        terminus self:info

--- a/README.md
+++ b/README.md
@@ -74,3 +74,28 @@ chmod +x terminus
 ./terminus self:update
 sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 ```
+
+### Standalone Docker container
+
+Terminus can also be built and run as a Docker container, rather than relying on system version of PHP and other dependencies.
+
+```bash
+docker build . -f Dockerfile -t terminus
+```
+
+In order to store configuration and install plugins, Terminus requires a persistent data directory. If you only plan to run Terminus via Docker, please run the following command to create a Docker data volume:
+
+```bash
+docker volume create terminus --ignore
+```
+
+The container can be run of 2 different ways:
+
+- Directly using `docker` (or `podman`, etc.):
+
+        docker run -tv terminus:/root/.terminus terminus:latest art
+
+- Alternatively implement an alias in your local environment:
+
+        alias terminus="docker run -tv ~/.terminus:/root/.terminus terminus:latest"
+        terminus art

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The container can be run of 2 different ways:
 
 - Directly using `docker` (or `podman`, etc.):
 
-        docker run -tv terminus:/root/.terminus terminus:latest art
+        docker run -tv terminus:/root/.terminus terminus:latest self:info
 
 - Alternatively implement an alias in your local environment:
 
         alias terminus="docker run -tv ~/.terminus:/root/.terminus terminus:latest"
-        terminus art
+        terminus self:info

--- a/README.md
+++ b/README.md
@@ -84,4 +84,10 @@ mkdir -p ~/.terminus
 docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest self:info
 ```
 
-See [docs/docker.md](docs/docker.md) for image tags, aliases, plugins, and how the images are built.
+For convenience, add an alias to your shell:
+
+```bash
+alias terminus="docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest"
+```
+
+See [docs/docker.md](docs/docker.md) for image tags, plugins, and how the images are built.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 Terminus can also be built and run as a Docker container, rather than relying on system version of PHP and other dependencies.
 
 ```bash
-docker build . -f Dockerfile -t terminus
+docker build . -t terminus
 ```
 
 In order to store configuration and install plugins, Terminus requires a persistent data directory. If you only plan to run Terminus via Docker, please run the following command to create a Docker data volume:

--- a/README.md
+++ b/README.md
@@ -77,32 +77,11 @@ sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 
 ### Standalone Docker container
 
-As an alternative to the standalone PHAR above, Terminus is also published as a Docker image, so it can run without a local PHP environment or other system dependencies. The image runs as a non-root `terminus` user.
-
-Each tagged release is published to the [GitHub Container Registry](https://github.com/pantheon-systems/terminus/pkgs/container/terminus). Pull the tag you want — a specific version, a major version, or `latest`:
-
-```bash
-docker pull ghcr.io/pantheon-systems/terminus:latest
-```
-
-Terminus stores your machine token, configuration, and installed plugins in `~/.terminus`. Bind-mount your local `~/.terminus` directory into the container so that data is written to — and persists on — your local filesystem:
+Terminus is also published as a Docker image, so it can run without a local PHP environment. Each tagged release is available from the GitHub Container Registry. Bind-mount your local `~/.terminus` so configuration and plugins persist:
 
 ```bash
 mkdir -p ~/.terminus
 docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest self:info
 ```
 
-For convenience, add an alias to your shell. Plugins you install are written to your local `~/.terminus` and remain available on subsequent runs:
-
-```bash
-alias terminus="docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest"
-terminus auth:login --machine-token=<token>
-terminus self:plugin:install <Packagist project or local path>
-```
-
-Alternatively, build the image from a local checkout of this repository instead of pulling it:
-
-```bash
-docker build . -t terminus
-docker run --rm -tv ~/.terminus:/home/terminus/.terminus terminus self:info
-```
+See [docs/docker.md](docs/docker.md) for image tags, aliases, plugins, and how the images are built.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -52,6 +52,30 @@ docker build . -t terminus
 docker run --rm -tv ~/.terminus:/home/terminus/.terminus terminus self:info
 ```
 
+## Verifying the image locally
+
+The `test_docker_image` job in
+[`.github/workflows/4.x.yml`](../.github/workflows/4.x.yml) builds the image and
+confirms that a plugin installed from a local path — stored in a bind-mounted
+`~/.terminus` — is still available on a later run. To reproduce that check
+locally:
+
+```bash
+docker build . -t terminus
+git clone https://github.com/pantheon-systems/terminus-plugin-example.git /tmp/plugin-src
+
+# Install the plugin from the mounted local path.
+docker run --rm -v ~/.terminus:/home/terminus/.terminus -v /tmp/plugin-src:/plugin-src \
+  terminus self:plugin:install /plugin-src
+
+# Run it from a fresh container using the persisted ~/.terminus.
+docker run --rm -v ~/.terminus:/home/terminus/.terminus -v /tmp/plugin-src:/plugin-src \
+  terminus hello
+```
+
+The final command prints `Hello, World!`, confirming the image runs and the
+local `~/.terminus` setup persists installed plugins.
+
 ## How the images are built
 
 The [`Dockerfile`](../Dockerfile) uses a multi-stage build:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,74 @@
+# Running Terminus with Docker
+
+Terminus is published as a Docker image, so it can run without a local PHP
+environment or other system dependencies. The image runs as a non-root
+`terminus` user.
+
+## Pulling an image
+
+Each tagged release is published to the
+[GitHub Container Registry](https://github.com/pantheon-systems/terminus/pkgs/container/terminus).
+Pull the tag you want — a specific version, a major version, or `latest`:
+
+```bash
+docker pull ghcr.io/pantheon-systems/terminus:4.3.2   # a specific release
+docker pull ghcr.io/pantheon-systems/terminus:4       # the latest 4.x release
+docker pull ghcr.io/pantheon-systems/terminus:latest  # the latest release
+```
+
+## Persisting configuration and plugins
+
+Terminus stores your machine token, configuration, and installed plugins in
+`~/.terminus`. Bind-mount your local `~/.terminus` directory into the container
+so that data is written to — and persists on — your local filesystem:
+
+```bash
+mkdir -p ~/.terminus
+docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest self:info
+```
+
+For convenience, add an alias to your shell:
+
+```bash
+alias terminus="docker run --rm -tv ~/.terminus:/home/terminus/.terminus ghcr.io/pantheon-systems/terminus:latest"
+terminus auth:login --machine-token=<token>
+```
+
+Because `~/.terminus` lives on your local filesystem, plugins you install remain
+available on subsequent runs — including plugins installed from a local path:
+
+```bash
+terminus self:plugin:install pantheon-systems/terminus-plugin-example
+terminus self:plugin:install /path/to/your/plugin
+```
+
+## Building the image locally
+
+Instead of pulling a published image, you can build one from a local checkout of
+this repository:
+
+```bash
+docker build . -t terminus
+docker run --rm -tv ~/.terminus:/home/terminus/.terminus terminus self:info
+```
+
+## How the images are built
+
+The [`Dockerfile`](../Dockerfile) uses a multi-stage build:
+
+1. **Composer layer** — provides the `composer` binary.
+2. **Build layer** — installs the production Composer dependencies and compiles
+   `terminus.phar` with [Box](https://github.com/box-project/box) on a
+   `php:8.4-cli-alpine` base.
+3. **Runtime layer** — copies the compiled `terminus.phar` onto a fresh
+   `php:8.4-cli-alpine` base with `git`, `openssh`, and `unzip`, creates the
+   non-root `terminus` user (UID/GID 1000, so a bind-mounted `~/.terminus` from
+   the typical first local user stays writable), and sets the phar as the
+   entrypoint.
+
+Each tagged release is published to the GitHub Container Registry by the
+`publish_docker_image` job in
+[`.github/workflows/4.x.yml`](../.github/workflows/4.x.yml). That job builds the
+image from the tagged source and pushes it with version tags derived from the
+release tag (for example `4.3.2`, `4.3`, `4`, and `latest`), OCI labels that
+record the source commit, and a build-provenance attestation.


### PR DESCRIPTION
Jira: [DEVX-7424](https://getpantheon.atlassian.net/browse/DEVX-7424)

For customers who cannot (or prefer not to) maintain a local PHP environment, this PR adds a supported way to run Terminus from a Docker image — and to publish that image automatically with every release.

### Image

- New multi-stage [`Dockerfile`](Dockerfile): a Composer layer and a Box build layer compile `terminus.phar`, which is copied onto a slim `php:8.4-cli-alpine` runtime with `git`, `openssh`, and `unzip`.
- Runs as a **non-root `terminus` user** (UID/GID 1000) with the phar as the entrypoint.
- Configuration and plugins are read from `~/.terminus`, so a bind-mounted local `~/.terminus` persists your machine token and installed plugins — including plugins installed from a local path — on your own filesystem.

### Publishing on release

- A `publish_docker_image` job publishes the image to the GitHub Container Registry (`ghcr.io/pantheon-systems/terminus`) on each tagged release, using the built-in `GITHUB_TOKEN` (no new secrets).
- `docker/metadata-action` tags each release with the full version, major.minor, major, and `latest` (e.g. `4.3.4`, `4.3`, `4`, `latest`), applies OCI labels (including the source commit), and generates a build-provenance attestation.
- The job is chained `needs: [ release ]`, so an image is published **when — and only when — the GitHub release is created**. The existing phar `release` job is unchanged.

### Testing

- A `test_docker_image` CI job runs on every push: it builds the image, installs the example plugin from a bind-mounted local `~/.terminus`, and runs it from a fresh container — verifying the image works and the local-filesystem setup persists plugins.
- The publishing job was validated end-to-end against a fork's GHCR namespace (registry login → tag matrix → build/push → attestation). See the testing comment below for full results.

### Documentation

- A short Docker section in [`README.md`](README.md) (pull, run with a persisted `~/.terminus`, and a shell alias), matching the length of the other installation methods.
- Full details in [`docs/docker.md`](docs/docker.md): image tags, persistence, plugins, building locally, reproducing the local verification test, and how the images are built and published.


[DEVX-7424]: https://getpantheon.atlassian.net/browse/DEVX-7424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ