### PR TITLE
[patch] Fix drush_version field in env:info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 
 - Add "PHP Runtime Generation" (php_runtime_generation) and "PHP Version" (php_version) to the `env:list` command (#2729, #2732)
+- Fix output of drush_version in `env:info` (#2736)
 
 ## 4.0.3 - 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 
 ### Fixed
+- Fix output of drush_version in `env:info` (#2736)
 
 ## 4.1.0 - 2025-09-29
 
 ### Added
 
 - Add "PHP Runtime Generation" (php_runtime_generation) and "PHP Version" (php_version) to the `env:list` command (#2729, #2732)
-- Fix output of drush_version in `env:info` (#2736)
 
 ### Fixed
 

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -621,7 +621,7 @@ class Environment extends TerminusModel implements
      */
     public function getDrushVersion()
     {
-        return $this->settings('drush_version');
+        return $this->settings('appserver_runtime')->drush_version;
     }
 
     /**
@@ -957,6 +957,7 @@ class Environment extends TerminusModel implements
             'initialized' => $this->isInitialized(),
             'connection_mode' => $this->get('connection_mode'),
             'php_version' => $this->getPHPVersion(),
+            'drush_version' => $this->getDrushVersion(),
             'php_runtime_generation' => $this->getPHPRuntimeGeneration(),
         ];
     }

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -319,6 +319,29 @@ class EnvCommandsTest extends TerminusTestBase
 
     /**
      * @test
+     * @covers \Pantheon\Terminus\Commands\Env\InfoCommand
+     *
+     * @group env
+     * @group short
+     */
+    public function testInfoCommandWithDrushVersion()
+    {
+        $envInfo = $this->terminusJsonResponse(
+            sprintf('env:info %s --field=drush_version', $this->getSiteEnv())
+        );
+        $this->assertArrayHasKey(
+            'drush_version',
+            $envInfo,
+            'Environment info should have "drush_version" field when explicitly requested.'
+        );
+        $this->assertNotEmpty(
+            $envInfo['drush_version'],
+            'Environment info "drush_version" should not be empty.'
+        );
+    }
+
+    /**
+     * @test
      * @covers \Pantheon\Terminus\Commands\Env\MetricsCommand
      *
      * @group env

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -327,7 +327,7 @@ class EnvCommandsTest extends TerminusTestBase
     public function testInfoCommandWithDrushVersion()
     {
         $envInfo = $this->terminusJsonResponse(
-            sprintf('env:info %s --field=drush_version', $this->getSiteEnv())
+            sprintf('env:info %s --fields=drush_version', $this->getSiteEnv())
         );
         $this->assertArrayHasKey(
             'drush_version',


### PR DESCRIPTION
## Summary
Fixes drush_version field returning blank values in env:info command. drush_version is defined in env:info, but appears to have never worked since the method was introduced.
- Update getDrushVersion() to use appserver_runtime.drush_version instead of deprecated drush_version setting
- Add drush_version to Environment serialize() method for env:info output
- Add test case

🤖 Generated with [Claude Code](https://claude.ai/code)


```
./bin/terminus env:info --fields=drush_version $MY_SITE.dev
 --------------- ---
  Drush Version   8
 --------------- ---
 ```
--------------

This command only returns the _platform configured_ drush version in pantheon.yml. Most modern Drupal applications (Composer-driven) on Pantheon use the site local Drush instead. It is worth considering whether we should deprecate and remove this field as well.
```
% ./bin/terminus env:info --fields=drush_version $MY_D11_SITE.dev
 --------------- ----
  Drush Version   10
 --------------- ----
% ./bin/terminus drush $MY_D11_SITE.dev -- --version
Drush Commandline Tool 13.6.2.0
```