### PR TITLE
[DEVX-5757] Release Terminus 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file. This projec
 
 - Add "PHP Runtime Generation" (php_runtime_generation) and "PHP Version" (php_version) to the `env:list` command (#2729, #2732)
 
+### Fixed
+
+- Fix workflow:wait timeout to use warnings instead of errors (#2724)
+- Preserve consolidation filter hook when running composer update class list (#2728)
+
 ## 4.0.3 - 2025-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.0.4-dev
+## [4.1.0] - 2025-09-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Fix workflow:wait timeout to use warnings instead of errors (#2724)
-- Preserve consolidation filter hook when running composer update class list (#2728)
 
 ## 4.0.3 - 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## [4.1.0] - 2025-09-29
+## 4.1.0 - 2025-09-29
 
 ### Added
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.0.4-dev'
+TERMINUS_VERSION: '4.1.0'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

Update version numbers for Terminus 4.1.0 release.

This release includes:
- Add "PHP Runtime Generation" (php_runtime_generation) and "PHP Version" (php_version) to the `env:list` command (#2729, #2732)

## Changes

- Updated `TERMINUS_VERSION` in `config/constants.yml` to `4.1.0`
- Updated changelog header from `4.0.4-dev` to `[4.1.0] - 2025-09-29`

CCB ticket: https://getpantheon.atlassian.net/browse/CCB-1977
