### PR TITLE
[DEVX-5790] Auto-detect URLs for db clone search-replace

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -176,6 +176,10 @@ class Environment extends TerminusModel implements
         if (!empty($options['from_url']) && !empty($options['to_url'])) {
             $params['wp_replace_siteurl']['from_url'] = $options['from_url'];
             $params['wp_replace_siteurl']['to_url'] = $options['to_url'];
+        } else {
+            // Automatically detect environment URLs for search-replace
+            $params['wp_replace_siteurl']['from_url'] = 'https://' . $from_env->domain();
+            $params['wp_replace_siteurl']['to_url'] = 'https://' . $this->domain();
         }
         return $this->getWorkflows()->create(
             'clone_database',


### PR DESCRIPTION
### Summary
Automatically populate wp_replace_siteurl parameter when cloning database content, matching Dashboard behavior. Previously only worked when --from-url and --to-url flags were explicitly provided.

### Testing
<img width="1661" height="161" alt="image" src="https://github.com/user-attachments/assets/b4286182-43d2-46d8-afd9-bd5bc483b4c6" />
