### PR TITLE
Release terminus 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.1-dev
+## 4.1.1 - 2025-11-04
 
 ### Added
+- Auto-detect URLs for db clone search-replace (#2738)
 
 ### Fixed
 - Fix output of drush_version in `env:info` (#2736)

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.1-dev'
+TERMINUS_VERSION: '4.1.1'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary
This PR updates Terminus to version 4.1.1.

## Changes
- Update TERMINUS_VERSION to 4.1.1 in config/constants.yml
- Update CHANGELOG.md with release date 2025-11-04

## Changelog
### Added
- Auto-detect URLs for db clone search-replace (#2738)

### Fixed
- Fix output of drush_version in `env:info` (#2736)

## Related
- CCB: https://getpantheon.atlassian.net/browse/CCB-2111