### PR TITLE
[DEVX-5946] Add timestamps to all logger output messages

### DIFF
--- a/src/Log/TimestampedLogOutputStyler.php
+++ b/src/Log/TimestampedLogOutputStyler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pantheon\Terminus\Log;
+
+use Consolidation\Log\LogOutputStyler;
+
+/**
+ * Extended log output styler that adds timestamps to all log messages.
+ *
+ * Formats timestamps as "YYYY-MM-DD hh:mm:ss UTC[+/-offset]" in local timezone.
+ */
+class TimestampedLogOutputStyler extends LogOutputStyler
+{
+    /**
+     * Generate a timestamp string in the format "YYYY-MM-DD hh:mm:ss UTC[+/-offset]"
+     *
+     * @return string The formatted timestamp
+     */
+    private function getTimestamp(): string
+    {
+        $now = new \DateTime();
+        $timezone = $now->getTimezone();
+        $offset = $now->getOffset();
+
+        // Format the offset as +/-HHMM
+        $offsetHours = abs($offset) / 3600;
+        $offsetMinutes = (abs($offset) % 3600) / 60;
+        $offsetSign = $offset >= 0 ? '+' : '-';
+        $offsetFormatted = sprintf('%s%02d%02d', $offsetSign, $offsetHours, $offsetMinutes);
+        return $now->format('Y-m-d H:i:s') . ' UTC[' . $offsetFormatted . ']';
+    }
+
+    /**
+     * Apply styling with the provided label and message styles, with timestamp prepended.
+     *
+     * @param string $label The log level label
+     * @param string $message The log message
+     * @param array $context The log context
+     * @param string $labelStyle The style for the label
+     * @param string $messageStyle The style for the message
+     * @return string The formatted log message with timestamp
+     */
+    protected function formatMessage($label, $message, $context, $labelStyle, $messageStyle = '')
+    {
+        // Get the original formatted message with colors
+        $originalMessage = parent::formatMessage($label, $message, $context, $labelStyle, $messageStyle);
+
+        // Prepend timestamp to the original formatted message
+        return $this->getTimestamp() . $originalMessage;
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -132,7 +132,15 @@ EOD;
         $this->addDefaultArgumentsAndOptions($application);
         $this->configureContainer();
         Robo::finalizeContainer($this->getContainer());
-        $this->setLogger($container->get('logger'));
+
+        // Configure the logger to use timestamps
+        $logger = $container->get('logger');
+        if ($logger instanceof \Consolidation\Log\Logger) {
+            $timestampedStyler = new \Pantheon\Terminus\Log\TimestampedLogOutputStyler();
+            $logger->setLogOutputStyler($timestampedStyler);
+        }
+
+        $this->setLogger($logger);
         $this->addBuiltInCommandsAndHooks();
         $this->addPluginsCommandsAndHooks();
 


### PR DESCRIPTION
## Summary
Add timestamps to all logger output messages in the YYYY-MM-DD hh:mm:ss UTC[+/-offset] format using the local timezone.

## Changes
- Created `TimestampedLogOutputStyler` class that extends `LogOutputStyler` to preserve colors and formatting
- Modified `Terminus.php` to configure the logger with the timestamped styler after Robo container setup
- Timestamps are prepended to all log messages while maintaining original styling and color

## Test plan
- [x] Verify timestamps appear on all log levels (notice, warning, error, debug)
- [x] Confirm original formatting and colors are preserved
- [x] Test with various Terminus commands to ensure consistent behavior
- [x] Validate timestamp format matches specification: YYYY-MM-DD hh:mm:ss UTC[+/-offset]

## Example output
```
2025-11-06 14:55:03 UTC[+0000] [notice] Command: example-site.live -- drush status [Exit: 0] (Attempt 1/1)
2025-11-06 14:55:03 UTC[+0000] [error] Command failed with exit code 1
```