### PR TITLE
Add --curl-debug option for verbose HTTP debugging

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -155,6 +155,14 @@ class Request implements
                     'handler' => $stack,
                 ];
 
+            // Enable cURL debug output if --curl-debug option is set
+            if ($this->getContainer()->has('input')) {
+                $input = $this->getContainer()->get('input');
+                if ($input->hasOption('curl-debug') && $input->getOption('curl-debug')) {
+                    $params['debug'] = true;
+                }
+            }
+
             $host_cert = $config->get('host_cert');
             if ($host_cert !== null) {
                 $params[RequestOptions::CERT] = $host_cert;

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -178,6 +178,9 @@ EOD;
         $app->getDefinition()->addOption(
             new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer all confirmations with "yes"')
         );
+        $app->getDefinition()->addOption(
+            new InputOption('--curl-debug', null, InputOption::VALUE_NONE, 'Enable verbose cURL debug output for troubleshooting TLS and connection issues')
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a new global `--curl-debug` CLI option that enables verbose cURL output to help troubleshoot TLS and connection issues.

## Problem

Customers sometimes receive "Connection refused" errors from Terminus when TLS is not working correctly. Common causes include:
- Misconfigured system CA certificates  
- Incorrect system clocks causing TLS validation failures
- Network connectivity problems

Currently, customers get minimal error information and often submit bug reports or contact support about perceived service outages when the issue is actually on their local system.

## Solution

This PR adds a `--curl-debug` option that enables Guzzle's debug mode, which leverages cURL's `CURLOPT_VERBOSE` option to provide detailed HTTP transaction information including:

- Connection establishment details
- TLS handshake information 
- HTTP headers and progress
- Transfer details

## Usage

```bash
# Enable debug output for any command
terminus auth:whoami --curl-debug
terminus site:list --curl-debug

# Test with intentionally broken TLS setup
TERMINUS_HOST=invalid-cert.example.com terminus self:info --curl-debug
```

## Example Output

When enabled, users see detailed connection information:
```
<GET https://terminus.pantheon.io/api/users/...> [CONNECT] 
<GET https://terminus.pantheon.io/api/users/...> [MIME_TYPE_IS] message: "application/json" 
<GET https://terminus.pantheon.io/api/users/...> [PROGRESS] bytes_transferred: "1164"
```

## Test Plan

- [x] Verify `--curl-debug` option appears in help output
- [x] Test with working API calls to confirm debug output 
- [x] Test with invalid TLS scenarios to verify error diagnosis capability
- [x] Confirm option works globally across all commands
- [x] Verify no impact on normal operation when flag not used

## Implementation Details

- Added global CLI option in `src/Terminus.php`
- Modified HTTP client configuration in `src/Request/Request.php` to check for the option
- Uses Guzzle's built-in `debug => true` parameter which activates cURL verbose mode
- No breaking changes - purely additive functionality