### PR TITLE
Fix: Forward COMPOSER_AUDIT_BLOCK_INSECURE and other env vars to Composer subprocess

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
     "psr-4": {
       "Pantheon\\Terminus\\Tests\\Functional\\": "tests/Functional/",
       "Pantheon\\Terminus\\FeatureTests\\": "tests/features/bootstrap/",
-      "Pantheon\\Terminus\\Scripts\\": "scripts/"
+      "Pantheon\\Terminus\\Scripts\\": "scripts/",
+      "Pantheon\\Terminus\\UnitTests\\": "tests/unit_tests/"
     },
     "classmap": [
       "scripts/UpdateClassLists.php"
@@ -109,6 +110,12 @@
     ],
     "test:behat": [
       "SHELL_INTERACTIVE=true TERMINUS_TEST_MODE=1 behat --colors --config tests/config/behat.yml --stop-on-failure --suite=default"
+    ],
+    "test:unit": [
+      "vendor/bin/phpunit --colors=always -c ./phpunit.unit.xml --debug --do-not-cache-result --verbose --stop-on-failure"
+    ],
+    "tests:unit": [
+      "@test:unit"
     ],
     "test:short": [
       "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=short --do-not-cache-result --verbose --stop-on-failure"

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/unit_tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">tests/unit_tests/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <server name="TERMINUS_CACHE_DIR" value="${TERMINUS_CACHE_DIR}" />
+    </php>
+</phpunit>
+

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -180,7 +180,91 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
         $config = $this->getConfig();
         $process->setTimeout($config->get('timeout'));
 
+        // Forward environment variables to the subprocess.
+        // This allows users to control Composer behavior (e.g., COMPOSER_AUDIT_BLOCK_INSECURE)
+        // and other subprocess behavior via TERMINUS_FORWARD_ENV.
+        $forwardedVars = $this->getForwardedEnvironment();
+        if (!empty($forwardedVars)) {
+            // Merge forwarded vars with the current process environment.
+            // We need to get all environment variables and merge with forwarded ones.
+            // Use getenv() to get actual environment variables (not all $_SERVER keys are env vars).
+            $currentEnv = [];
+            // Get all environment variables using getenv() for each known env var from $_SERVER
+            // This ensures we only get actual environment variables, not other $_SERVER keys.
+            foreach ($_SERVER as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    // Verify this is actually an environment variable by checking getenv()
+                    $envValue = getenv($key);
+                    if ($envValue !== false) {
+                        $currentEnv[$key] = $envValue;
+                    }
+                }
+            }
+            // Also check $_ENV for any additional variables
+            foreach ($_ENV as $key => $value) {
+                if (is_string($key) && is_string($value) && !isset($currentEnv[$key])) {
+                    $currentEnv[$key] = $value;
+                }
+            }
+            // Merge: start with current env, then override with forwarded vars
+            $env = array_merge($currentEnv, $forwardedVars);
+            $process->setEnv($env);
+        }
+
         return $process;
+    }
+
+    /**
+     * Gets the environment variables that should be forwarded to subprocesses.
+     *
+     * This method:
+     * - Always forwards Composer-related environment variables (e.g., COMPOSER_AUDIT_BLOCK_INSECURE)
+     *   to allow users to control Composer's security audit behavior during plugin installation.
+     * - Forwards any variables specified in TERMINUS_FORWARD_ENV (comma-separated list).
+     *
+     * Note: We do not globally disable Composer audits. We only respect explicit user
+     * instructions via environment variables.
+     *
+     * @return array Environment variables to forward (key => value pairs), or empty array if none to forward
+     */
+    protected function getForwardedEnvironment(): array
+    {
+        $forwardedVars = [];
+
+        // Always forward Composer-related environment variables if they are set.
+        // This allows users to override Composer's security audit behavior.
+        $composerEnvVars = [
+            'COMPOSER_AUDIT_BLOCK_INSECURE',
+            'COMPOSER_ALLOW_SUPERUSER',
+            'COMPOSER_DISABLE_XDEBUG_WARN',
+            'COMPOSER_MEMORY_LIMIT',
+            'COMPOSER_MIRROR_PATH_REPOS',
+            'COMPOSER_NO_INTERACTION',
+            'COMPOSER_PROCESS_TIMEOUT',
+        ];
+
+        foreach ($composerEnvVars as $var) {
+            $value = getenv($var);
+            if ($value !== false) {
+                $forwardedVars[$var] = $value;
+            }
+        }
+
+        // Check for TERMINUS_FORWARD_ENV (comma-separated list of env var names to forward).
+        $terminusForwardEnv = getenv('TERMINUS_FORWARD_ENV');
+        if ($terminusForwardEnv !== false && !empty($terminusForwardEnv)) {
+            $varsToForward = array_map('trim', explode(',', $terminusForwardEnv));
+            foreach ($varsToForward as $varName) {
+                if (!empty($varName)) {
+                    $value = getenv($varName);
+                    if ($value !== false) {
+                        $forwardedVars[$varName] = $value;
+                    }
+                }
+            }
+        }
+
+        return $forwardedVars;
     }
 
     /**

--- a/tests/Functional/PluginManagerCommandsTest.php
+++ b/tests/Functional/PluginManagerCommandsTest.php
@@ -156,6 +156,85 @@ class PluginManagerCommandsTest extends TerminusTestBase
     }
 
     /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Self\Plugin\InstallCommand
+     *
+     * Regression test to verify that COMPOSER_AUDIT_BLOCK_INSECURE environment variable
+     * is properly forwarded to Composer subprocess during plugin installation.
+     *
+     * This test verifies the fix for the bug where COMPOSER_AUDIT_BLOCK_INSECURE=0
+     * was not being forwarded to Composer, causing plugin installations to fail
+     * with security advisory errors even when the user explicitly opted out.
+     *
+     * Uses terminus-build-tools-plugin which has known security advisories in its
+     * dependencies (e.g., symfony/process v5.4.40, twig/twig v3.11.1) to verify
+     * that the env var forwarding actually works end-to-end.
+     *
+     * @group plugins
+     * @group long
+     */
+    public function testPluginInstallRespectsComposerAuditBlockInsecureEnv()
+    {
+        $filesystem = new Filesystem();
+        // Use a plugin with known security advisories to test the env forwarding
+        $testPluginPackage = 'pantheon-systems/terminus-build-tools-plugin';
+
+        // Clean up.
+        $filesystem->remove([
+            $this->getPluginsDir(),
+            $this->getPlugins2Dir(),
+            $this->getDependenciesBaseDir(),
+            $this->getBaseDir(),
+        ]);
+
+        // Uninstall plugin if it exists
+        $this->terminus('self:plugin:uninstall ' . $testPluginPackage, [], false);
+
+        // Test that plugin installation works with COMPOSER_AUDIT_BLOCK_INSECURE=0 set.
+        // This verifies that the environment variable is properly forwarded to Composer.
+        // Without this env var, Composer 2.9.1+ would block the installation due to
+        // security advisories in the plugin's dependencies.
+        $env = array_merge($this->env, ['COMPOSER_AUDIT_BLOCK_INSECURE' => '0']);
+        [$output, $exitCode, $error] = static::callTerminus(
+            sprintf('self:plugin:install %s', $testPluginPackage),
+            null,
+            $env
+        );
+
+        // The installation should succeed (exit code 0) when COMPOSER_AUDIT_BLOCK_INSECURE=0 is set.
+        // If the env var is not forwarded, Composer would fail with security advisory errors.
+        $this->assertEquals(
+            0,
+            $exitCode,
+            sprintf(
+                'Plugin installation should succeed with COMPOSER_AUDIT_BLOCK_INSECURE=0. ' .
+                'If this fails, the env var may not be forwarded to Composer. ' .
+                'Output: %s, Error: %s',
+                $output,
+                $error
+            )
+        );
+
+        // Verify the plugin was actually installed
+        $this->assertStringContainsString(
+            sprintf('Installed %s', $testPluginPackage),
+            $output . $error,
+            'Plugin installation output should indicate success.'
+        );
+
+        // Verify no security advisory blocking errors in the output
+        $combinedOutput = $output . $error;
+        $this->assertStringNotContainsString(
+            'are affected by security advisories',
+            $combinedOutput,
+            'Plugin installation should not show security advisory blocking errors when COMPOSER_AUDIT_BLOCK_INSECURE=0 is set.'
+        );
+
+        // Cleanup
+        $this->terminus('self:plugin:uninstall ' . $testPluginPackage, [], false);
+    }
+
+    /**
      * Install Terminus 2 plugins.
      *
      * @param array $plugins

--- a/tests/Functional/PluginManagerCommandsTest.php
+++ b/tests/Functional/PluginManagerCommandsTest.php
@@ -227,7 +227,8 @@ class PluginManagerCommandsTest extends TerminusTestBase
         $this->assertStringNotContainsString(
             'are affected by security advisories',
             $combinedOutput,
-            'Plugin installation should not show security advisory blocking errors when COMPOSER_AUDIT_BLOCK_INSECURE=0 is set.'
+            'Plugin installation should not show security advisory blocking errors '
+            . 'when COMPOSER_AUDIT_BLOCK_INSECURE=0 is set.'
         );
 
         // Cleanup

--- a/tests/unit_tests/Plugins/PluginEnvForwardingTest.php
+++ b/tests/unit_tests/Plugins/PluginEnvForwardingTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Plugins;
+
+use League\Container\Container;
+use Pantheon\Terminus\Config\TerminusConfig;
+use Pantheon\Terminus\Helpers\LocalMachineHelper;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class PluginEnvForwardingTest
+ *
+ * Regression test to ensure that environment variables (especially COMPOSER_AUDIT_BLOCK_INSECURE)
+ * are properly forwarded to Composer subprocesses during plugin installation.
+ *
+ * @package Pantheon\Terminus\UnitTests\Plugins
+ */
+class PluginEnvForwardingTest extends TerminusTestCase
+{
+    /**
+     * @var TerminusConfig
+     */
+    protected $config;
+
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var LocalMachineHelper
+     */
+    protected $local_machine;
+
+    /**
+     * @var array Original environment variables to restore in tearDown
+     */
+    protected $originalEnv = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = $this->getMockBuilder(TerminusConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->input = $this->getMockBuilder(InputInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->config->method('get')
+            ->with($this->equalTo('timeout'))
+            ->willReturn(300);
+        $this->input->method('isInteractive')
+            ->willReturn(false);
+
+        $this->local_machine = new LocalMachineHelper();
+        $this->local_machine->setConfig($this->config);
+        $this->local_machine->setInput($this->input);
+        $this->local_machine->setContainer($this->container);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tearDown(): void
+    {
+        // Restore original environment variables
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                putenv($var);
+            } else {
+                putenv("$var=$value");
+            }
+        }
+        $this->originalEnv = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * Helper to set an environment variable and track it for cleanup.
+     *
+     * @param string $var
+     * @param string|false $value
+     */
+    protected function setEnvVar(string $var, $value)
+    {
+        $original = getenv($var);
+        $this->originalEnv[$var] = $original;
+        if ($value === false) {
+            putenv($var);
+        } else {
+            putenv("$var=$value");
+        }
+    }
+
+    /**
+     * Tests that COMPOSER_AUDIT_BLOCK_INSECURE is forwarded to the Composer process.
+     *
+     * This is a regression test for the bug where COMPOSER_AUDIT_BLOCK_INSECURE=0
+     * was not being forwarded to the Composer subprocess during plugin installation,
+     * causing Composer to block insecure packages even when the user explicitly
+     * opted out via the environment variable.
+     */
+    public function testComposerAuditBlockInsecureIsForwarded()
+    {
+        // Set the environment variable that should be forwarded
+        $this->setEnvVar('COMPOSER_AUDIT_BLOCK_INSECURE', '0');
+
+        // Use reflection to access the protected getProcess method
+        $reflection = new \ReflectionClass($this->local_machine);
+        $getProcessMethod = $reflection->getMethod('getProcess');
+        $getProcessMethod->setAccessible(true);
+
+        // Create a process (this will internally call getForwardedEnvironment)
+        $process = $getProcessMethod->invoke($this->local_machine, 'composer --version');
+
+        // Verify that the process has the environment variable set
+        // We need to use reflection to access the env property or use a different approach
+        // Since Process doesn't expose getEnv(), we'll test by actually running a command
+        // that echoes the env var, or we can check the process's internal state.
+
+        // Actually, the best way is to verify that getForwardedEnvironment returns the var
+        $getForwardedEnvMethod = $reflection->getMethod('getForwardedEnvironment');
+        $getForwardedEnvMethod->setAccessible(true);
+        $forwardedEnv = $getForwardedEnvMethod->invoke($this->local_machine);
+
+        $this->assertArrayHasKey(
+            'COMPOSER_AUDIT_BLOCK_INSECURE',
+            $forwardedEnv,
+            'COMPOSER_AUDIT_BLOCK_INSECURE should be in forwarded environment variables'
+        );
+        $this->assertEquals(
+            '0',
+            $forwardedEnv['COMPOSER_AUDIT_BLOCK_INSECURE'],
+            'COMPOSER_AUDIT_BLOCK_INSECURE should have value "0"'
+        );
+    }
+
+    /**
+     * Tests that TERMINUS_FORWARD_ENV can be used to forward additional variables.
+     */
+    public function testTerminusForwardEnvForwardsAdditionalVars()
+    {
+        // Set a custom env var and specify it in TERMINUS_FORWARD_ENV
+        $this->setEnvVar('MY_CUSTOM_VAR', 'my-custom-value');
+        $this->setEnvVar('TERMINUS_FORWARD_ENV', 'MY_CUSTOM_VAR');
+
+        $reflection = new \ReflectionClass($this->local_machine);
+        $getForwardedEnvMethod = $reflection->getMethod('getForwardedEnvironment');
+        $getForwardedEnvMethod->setAccessible(true);
+        $forwardedEnv = $getForwardedEnvMethod->invoke($this->local_machine);
+
+        $this->assertArrayHasKey(
+            'MY_CUSTOM_VAR',
+            $forwardedEnv,
+            'MY_CUSTOM_VAR should be forwarded when specified in TERMINUS_FORWARD_ENV'
+        );
+        $this->assertEquals(
+            'my-custom-value',
+            $forwardedEnv['MY_CUSTOM_VAR'],
+            'MY_CUSTOM_VAR should have the correct value'
+        );
+    }
+
+    /**
+     * Tests that multiple variables can be forwarded via TERMINUS_FORWARD_ENV.
+     */
+    public function testTerminusForwardEnvForwardsMultipleVars()
+    {
+        $this->setEnvVar('VAR1', 'value1');
+        $this->setEnvVar('VAR2', 'value2');
+        $this->setEnvVar('TERMINUS_FORWARD_ENV', 'VAR1,VAR2');
+
+        $reflection = new \ReflectionClass($this->local_machine);
+        $getForwardedEnvMethod = $reflection->getMethod('getForwardedEnvironment');
+        $getForwardedEnvMethod->setAccessible(true);
+        $forwardedEnv = $getForwardedEnvMethod->invoke($this->local_machine);
+
+        $this->assertArrayHasKey('VAR1', $forwardedEnv);
+        $this->assertArrayHasKey('VAR2', $forwardedEnv);
+        $this->assertEquals('value1', $forwardedEnv['VAR1']);
+        $this->assertEquals('value2', $forwardedEnv['VAR2']);
+    }
+
+    /**
+     * Tests that Composer env vars are forwarded even when TERMINUS_FORWARD_ENV is not set.
+     */
+    public function testComposerVarsForwardedWithoutTerminusForwardEnv()
+    {
+        $this->setEnvVar('COMPOSER_AUDIT_BLOCK_INSECURE', '0');
+        // Explicitly unset TERMINUS_FORWARD_ENV
+        $this->setEnvVar('TERMINUS_FORWARD_ENV', false);
+
+        $reflection = new \ReflectionClass($this->local_machine);
+        $getForwardedEnvMethod = $reflection->getMethod('getForwardedEnvironment');
+        $getForwardedEnvMethod->setAccessible(true);
+        $forwardedEnv = $getForwardedEnvMethod->invoke($this->local_machine);
+
+        $this->assertArrayHasKey(
+            'COMPOSER_AUDIT_BLOCK_INSECURE',
+            $forwardedEnv,
+            'COMPOSER_AUDIT_BLOCK_INSECURE should be forwarded even without TERMINUS_FORWARD_ENV'
+        );
+    }
+
+    /**
+     * Tests that unset environment variables are not included in forwarded env.
+     */
+    public function testUnsetVarsNotForwarded()
+    {
+        // Don't set COMPOSER_AUDIT_BLOCK_INSECURE
+        $this->setEnvVar('COMPOSER_AUDIT_BLOCK_INSECURE', false);
+
+        $reflection = new \ReflectionClass($this->local_machine);
+        $getForwardedEnvMethod = $reflection->getMethod('getForwardedEnvironment');
+        $getForwardedEnvMethod->setAccessible(true);
+        $forwardedEnv = $getForwardedEnvMethod->invoke($this->local_machine);
+
+        $this->assertArrayNotHasKey(
+            'COMPOSER_AUDIT_BLOCK_INSECURE',
+            $forwardedEnv,
+            'Unset COMPOSER_AUDIT_BLOCK_INSECURE should not be in forwarded env'
+        );
+    }
+}

--- a/tests/unit_tests/TerminusTestCase.php
+++ b/tests/unit_tests/TerminusTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TerminusTestCase
+ * @package Pantheon\Terminus\UnitTests
+ */
+abstract class TerminusTestCase extends TestCase
+{
+}

--- a/tests/unit_tests/bootstrap.php
+++ b/tests/unit_tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Bootstrap file for unit tests
+ */
+
+// The CL args used to initialize these tests would change how Terminus runs.
+unset($GLOBALS['argv']);
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Override the default cache directory by setting an environment variable. This prevents our tests from overwriting
+// the user's real cache and session.
+// @TODO: Unit tests should not rely on side effects like these. When the Config object is properly injectable this
+// will not be necessary.
+$home = getenv('HOME');
+putenv("TERMINUS_CACHE_DIR=$home/.terminus/testcache");
+


### PR DESCRIPTION
When installing plugins via `terminus plugin:install` using PHP 8.3 and Composer 2.9.1+, the installation fails due to Composer security advisories even when the user explicitly sets `COMPOSER_AUDIT_BLOCK_INSECURE=0`.

The issue is that Terminus was not forwarding environment variables (specifically `COMPOSER_AUDIT_BLOCK_INSECURE`) to the Composer subprocess used during plugin installation. As a result, Composer's security audit system would block installations of plugins with known security advisories in their dependencies, even when users explicitly opted out.

### Example Error
```
Error executing command "composer require ...":
Your requirements could not be resolved to an installable set of packages.

Problem 1
  - Root composer.json requires symfony/process v5.4.40 (exact version match),
    found symfony/process[v5.4.40] but these were not loaded, because they are
    affected by security advisories. To ignore the advisories, add
    ("PKSA-wws7-mr54-jsny") to the audit "ignore" config. To turn the feature
    off entirely, you can set "block-insecure" to false in your "audit" config.
```

## Solution

This PR implements environment variable forwarding in `LocalMachineHelper::getProcess()` to ensure that:

1. **Composer-related environment variables are automatically forwarded** - Including `COMPOSER_AUDIT_BLOCK_INSECURE`, `COMPOSER_ALLOW_SUPERUSER`, `COMPOSER_MEMORY_LIMIT`, etc.
2. **TERMINUS_FORWARD_ENV support** - Users can forward additional environment variables via `TERMINUS_FORWARD_ENV=VAR1,VAR2`
3. **Applies to all commands** - The fix is in `LocalMachineHelper`, so it applies to plugin install, update, and any other command that uses this helper

### Key Changes

- **`src/Helpers/LocalMachineHelper.php`**:
  - Modified `getProcess()` to forward environment variables to subprocesses
  - Added `getForwardedEnvironment()` method that collects and returns env vars to forward
  - Automatically forwards Composer-related env vars if they are set
  - Supports `TERMINUS_FORWARD_ENV` for additional variables

- **Test Infrastructure**:
  - Added `tests/unit_tests/TerminusTestCase.php` - Base test case class
  - Added `tests/unit_tests/bootstrap.php` - Bootstrap for unit tests
  - Added `phpunit.unit.xml` - Separate PHPUnit config for unit tests
  - Updated `composer.json` to include unit test scripts and autoload config

- **Tests**:
  - **Unit tests** (`tests/unit_tests/Plugins/PluginEnvForwardingTest.php`): 5 test cases verifying env forwarding logic
  - **Functional test** (`tests/Functional/PluginManagerCommandsTest.php::testPluginInstallRespectsComposerAuditBlockInsecureEnv`): End-to-end test using `terminus-build-tools-plugin` (which has known security advisories)

## Testing

### Automated Tests
- ✅ All unit tests pass (5 tests, 10 assertions)
- ✅ Functional test verifies end-to-end behavior with a plugin that has security advisories

### Manual Validation
To validate the fix manually:

```bash
# Set up environment
brew unlink php
brew link php@8.3

# Uninstall plugin if it exists
terminus plugin:uninstall terminus-build-tools-plugin

# Verify versions
php -v  # Should show PHP 8.3
composer --version  # Should show Composer 2.9.1+
terminus --version

# Reload plugins
terminus plugin:reload

# Test the fix - this should now succeed
export COMPOSER_AUDIT_BLOCK_INSECURE=0
terminus plugin:install terminus-build-tools-plugin
```

**Expected Result**: Plugin installation succeeds without security advisory blocking errors.

**Without the fix**: Installation fails with Composer security advisory errors.

## Implementation Details

The fix works by:
1. Collecting environment variables that should be forwarded (Composer vars + TERMINUS_FORWARD_ENV)
2. Merging them with the current process environment
3. Setting the merged environment on the Symfony Process object before execution

This ensures that when Composer runs as a subprocess, it sees the same environment variables that the parent Terminus process sees, allowing users to control Composer's behavior via environment variables.

## Notes

- I did **not** globally disable Composer audit intentionally so that we are only respecting explicit user instructions via environment variables
- The fix applies to all commands using `LocalMachineHelper`, not just plugin installation
- Backward compatible - if no env vars are set, behavior is unchanged

## Related

- Composer 2.9.1+ introduced stricter security audit blocking behavior
- This fix ensures Terminus respects user overrides for Composer's audit system