### PR TITLE
Fix docs saying a name is passed in, when it's a UUID

### DIFF
--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -44,7 +44,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @option plan DEPRECATED Plan filter; filter by the plan's label
      * @option string $tag Tag name to filter (ANY)
      * @option string $tags Multiple tag names to filter (ALL)
-     * @option string $upstream Upstream name to filter
+     * @option string $upstream Upstream UUID to filter
      *
      * @usage <organization> Displays the list of sites associated with <organization>.
      * @usage <organization> --plan=<plan> Displays the list of sites associated with <organization> having the plan named <plan>.

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -48,7 +48,7 @@ class ListCommand extends SiteCommand
      * @option owner Owner filter; "me" or user UUID
      * @option plan DEPRECATED Plan filter; filter by the plan's label
      * @option team Team-only filter
-     * @option string $upstream Upstream name to filter
+     * @option string $upstream Upstream UUID to filter
      *
      * @usage Displays the list of all sites accessible to the currently logged-in user.
      * @usage --name=<regex> Displays a list of accessible sites with a name that matches <regex>.


### PR DESCRIPTION
The short docs say 'name' and the long docs say 'uuid'. Since the command accepts only UUIDs, I updated the docs to match.