### PR TITLE
[BUGS-10575] Consider a session active only if it's valid for more than 1 minute.

### DIFF
--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -119,7 +119,7 @@ class Session implements
     {
         return (
             isset($this->data->session)
-            && ($this->data->expires_at >= time() || (bool)$this->config->get(
+            && ($this->data->expires_at >= (time() + 60) || (bool)$this->config->get(
                 'test_mode'
             ))
         );

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -117,6 +117,7 @@ class Session implements
      */
     public function isActive()
     {
+        // Consider a session expired if it is already about to expire (less than 1 minute).
         return (
             isset($this->data->session)
             && ($this->data->expires_at >= (time() + 60) || (bool)$this->config->get(


### PR DESCRIPTION
Otherwise, Terminus may think it's valid but when it gets to the API it's no longer valid resulting in a confusing "Invalid or expired session header" message