### PR TITLE
[BUGS-10732] handle if is_initialized doesnt return a value for some reason

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -880,7 +880,12 @@ class Environment extends TerminusModel implements
             return true;
         }
 
-        return $this->settings('is_initialized');
+        $initialized = $this->settings('is_initialized');
+        // Fail safe - if we can't confirm it's NOT initialized, assume it IS
+        if ($initialized === null) {
+            return true;
+        }
+        return $initialized;
     }
 
     /**


### PR DESCRIPTION
if is_initialized isn't present, there's an edge case where a create_environment workflow can get run on an already existing environment.

https://github.com/pantheon-systems/titan-mt/pull/21398 adds checking in the backend to ensure that the workflow will exit early in such instances, but this PR adds early defense to prevent false positive runs.