### PR TITLE
[DEVX-6452] Do not rely on commit labels, instead compare commits between 2 envs.

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -400,16 +400,25 @@ class Environment extends TerminusModel implements
      */
     public function countDeployableCommits()
     {
+        $env_commits = $this->getCommits()->all();
         $parent_environment = $this->getParentEnvironment();
         $number_of_commits = 0;
         if ($parent_environment instanceof Environment) {
             $parent_commits = $parent_environment->getCommits()->all();
             foreach ($parent_commits as $commit) {
-                $labels = $commit->get('labels');
-                $number_of_commits += (int)(
-                    !in_array($this->id, $labels)
-                    && in_array($parent_environment->id, $labels)
-                );
+                $hash = $commit->get('hash');
+                $found = false;
+                foreach ($env_commits as $env_commit) {
+                    if ($env_commit->get('hash') === $hash) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if ($found) {
+                    // No need to continue checking commits.
+                    break;
+                }
+                $number_of_commits++;
             }
         }
         return $number_of_commits;


### PR DESCRIPTION
This will help adding support for evcs sites deployment from core Terminus and will also standardize the checking for deployable commits between dashboard and terminus.