### PR TITLE
Update version to 4.1.2 and finalize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.2-dev
+## 4.1.2 - 2026-01-27
 
 ### Added
 
+- Add timestamps to all logger output messages (#2745)
+
 ### Fixed
+
+- Consider a session active only if it's valid for more than 1 minute (#2758)
+- Handle if is_initialized doesn't return a value (#2760)
+- Do not rely on commit labels, instead compare commits between 2 envs (#2761)
 
 ## 4.1.1 - 2025-11-04
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.2-dev'
+TERMINUS_VERSION: '4.1.2'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

- Update TERMINUS_VERSION to 4.1.2
- Finalize changelog with 4.1.2 release date and entries

### Changes in 4.1.2

**Added:**
- Add timestamps to all logger output messages (#2745)

**Fixed:**
- Consider a session active only if it's valid for more than 1 minute (#2758)
- Handle if is_initialized doesn't return a value (#2760)
- Do not rely on commit labels, instead compare commits between 2 envs (#2761)

## Test plan

- [ ] CI tests pass
- [ ] Await 2 approvals
- [ ] CCB ticket approved before merging