### PR TITLE
Release version 4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.2-dev
+## 4.1.3 - 2026-01-29
 
 ### Added
+- Add timestamps to all logger output messages (#2745)
 
 ### Fixed
+- Disable audit for plugins to resolve Composer security warnings blocking plugin installation (#2766)
+- Fix environment comparison to not rely on commit labels (#2761)
+- Handle cases where is_initialized doesn't return a value (#2760)
+- Consider a session active only if it's valid for more than 1 minute (#2758)
 
 ## 4.1.1 - 2025-11-04
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.2-dev'
+TERMINUS_VERSION: '4.1.3'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
This PR prepares Terminus release 4.1.3.

Changes include:
- Update TERMINUS_VERSION to 4.1.3  
- Update CHANGELOG.md with 4.1.3 release notes

Key fixes in this release:
- Fix Composer security warnings blocking plugin installation (#2766)
- Fix environment comparison to not rely on commit labels (#2761)
- Handle cases where is_initialized doesn't return a value (#2760) 
- Fix session validation timing (#2758)
- Add timestamps to all logger output messages (#2745)

Relates to BUGS-10860