### PR TITLE
[BUGS-10860] Disable audit block-insecure part two

### DIFF
--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -369,6 +369,7 @@ abstract class PluginBaseCommand extends TerminusCommand
             $this->runCommand("composer --working-dir=$path init --name=$package_name -n");
             $this->runCommand("composer --working-dir=$path config minimum-stability dev");
             $this->runCommand("composer --working-dir=$path config prefer-stable true");
+            $this->runCommand("composer --working-dir=$path config audit.block-insecure false");
         }
     }
 


### PR DESCRIPTION
Ensure that the Terminus plugins composer.json file also disables audit block-insecure, because it is used as the root composer.json file for plugin operations.