### PR TITLE
Back to dev: 4.1.5-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.1.5-dev
+
+### Added
+
+### Fixed
+
 ## 4.1.4 - 2026-02-02
 
 ### Added

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.4'
+TERMINUS_VERSION: '4.1.5-dev'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

Updates the version number back to development after the 4.1.4 release.

- Updates `TERMINUS_VERSION` to `4.1.5-dev`
- Adds new changelog section for upcoming changes