### PR TITLE
Add unit tests and PHPStan to CI pipeline

### DIFF
--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -36,6 +36,8 @@ jobs:
         run: composer install
       - name: Validate Code
         run: composer code:lint
+      - name: Unit Tests & PHPStan
+        run: composer test:unit
       - name: Phar Build
         run: |
           mkdir $HOME/box

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -94,11 +94,11 @@ jobs:
           coverage: none
           ini-values: error_reporting=E_ALL
       - name: Download repo content from artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: full-workspace
       - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: terminus-phar
       - name: Install Composer Dependencies
@@ -133,7 +133,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
     steps:
       - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: terminus-phar
       - name: Release

--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -87,11 +87,11 @@ jobs:
         if: runner.os == 'macOS'
         continue-on-error: true
       - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: gd, mbstring, zip, ssh2-1.4.1, pcov
-          coverage: pcov
+          extensions: gd, mbstring, zip, ssh2-1.4.1
+          coverage: none
           ini-values: error_reporting=E_ALL
       - name: Download repo content from artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/bin/terminus
+++ b/bin/terminus
@@ -32,7 +32,7 @@ if (!getenv('TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP') && version_compare(PHP_VERSI
 
 // This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
 // which is run after every call to composer update.
-$terminusPluginsDependenciesVersion = '482eef7a4c';
+$terminusPluginsDependenciesVersion = '77b50130b0';
 
 // Cannot use $_SERVER superglobal since that's empty during phpunit testing
 // getenv('HOME') isn't set on Windows and generates a Notice.

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,9 @@
     "twig/twig": "^3.3"
   },
   "require-dev": {
-    "ext-pcov": "*",
     "behat/behat": "^3.2.2",
     "erusev/parsedown": "^1.7",
     "friendsofphp/php-cs-fixer": "^3.17",
-    "pcov/clobber": "^2.0",
-    "phpunit/php-code-coverage": "^9.2",
-    "phpunit/phpcov": "^8.2",
     "phpunit/phpunit": "^9",
     "squizlabs/php_codesniffer": "^3.5",
     "wdalmut/php-deb-packager": "^0.0.14"
@@ -114,13 +110,13 @@
       "vendor/bin/phpunit --colors=always -c ./phpunit-unit.xml --do-not-cache-result --verbose"
     ],
     "test:short": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=short --do-not-cache-result --verbose --stop-on-failure"
+      "vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=short --do-not-cache-result --verbose --stop-on-failure"
     ],
     "test:long": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=long --do-not-cache-result --verbose"
+      "vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=long --do-not-cache-result --verbose"
     ],
     "test:functional": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=short,long --do-not-cache-result --verbose",
+      "vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --group=short,long --do-not-cache-result --verbose",
       "@coverage"
     ],
     "test:all": [

--- a/composer.json
+++ b/composer.json
@@ -119,10 +119,7 @@
       "SHELL_INTERACTIVE=true TERMINUS_TEST_MODE=1 behat --colors --config tests/config/behat.yml --stop-on-failure --suite=default"
     ],
     "test:unit": [
-      "vendor/bin/phpunit --colors=always -c tests/config/phpunit.unit.xml --verbose"
-    ],
-    "test:quick": [
-      "@test:unit",
+      "vendor/bin/phpunit --colors=always -c tests/config/phpunit.unit.xml --verbose",
       "@phpstan"
     ],
     "test:short": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3248a03842fe8cb04abdc3f773adca97",
+    "content-hash": "21c93101d2ae0aa1843c521354e7dd80",
     "packages": [
         {
             "name": "composer/semver",
@@ -4285,40 +4285,6 @@
             "time": "2025-08-01T08:46:24+00:00"
         },
         {
-            "name": "pcov/clobber",
-            "version": "v2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/krakjoe/pcov-clobber.git",
-                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
-                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcov": "^1.0",
-                "nikic/php-parser": "^4.2"
-            },
-            "bin": [
-                "bin/pcov"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "pcov\\Clobber\\": "src/pcov/clobber"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "support": {
-                "issues": "https://github.com/krakjoe/pcov-clobber/issues",
-                "source": "https://github.com/krakjoe/pcov-clobber/tree/v2.0.3"
-            },
-            "time": "2019-10-29T05:03:37+00:00"
-        },
-        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -4754,68 +4720,6 @@
                 }
             ],
             "time": "2020-10-26T13:16:10+00:00"
-        },
-        {
-            "name": "phpunit/phpcov",
-            "version": "8.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpcov.git",
-                "reference": "8ec45dde34a84914a0ace355fbd6d7af2242c9a4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/8ec45dde34a84914a0ace355fbd6d7af2242c9a4",
-                "reference": "8ec45dde34a84914a0ace355fbd6d7af2242c9a4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2",
-                "phpunit/php-file-iterator": "^3.0",
-                "phpunit/phpunit": "^9.3",
-                "sebastian/cli-parser": "^1.0",
-                "sebastian/diff": "^4.0",
-                "sebastian/version": "^3.0"
-            },
-            "bin": [
-                "phpcov"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "8.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "CLI frontend for php-code-coverage",
-            "homepage": "https://github.com/sebastianbergmann/phpcov",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpcov/issues",
-                "source": "https://github.com/sebastianbergmann/phpcov/tree/8.2.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-03-24T12:07:05+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -7383,9 +7287,7 @@
         "php": ">=8.2",
         "ext-json": "*"
     },
-    "platform-dev": {
-        "ext-pcov": "*"
-    },
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.26"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,10 +37,82 @@ parameters:
 			path: src/Commands/Local/DockerizeCommand.php
 
 		-
+			message: '#^Call to an undefined method Pantheon\\Terminus\\Commands\\Org\\People\\AddCommand\:\:getSiteById\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Commands/Org/People/AddCommand.php
+
+		-
+			message: '#^Call to an undefined method Pantheon\\Terminus\\Commands\\Org\\People\\RemoveCommand\:\:getSiteById\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Commands/Org/People/RemoveCommand.php
+
+		-
+			message: '#^Call to an undefined method Pantheon\\Terminus\\Commands\\Org\\People\\RoleCommand\:\:getSiteById\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Commands/Org/People/RoleCommand.php
+
+		-
+			message: '#^Anonymous function has an unused use \$output\.$#'
+			identifier: closure.unusedUse
+			count: 1
+			path: src/Commands/Remote/SSHBaseCommand.php
+
+		-
+			message: '#^Anonymous function has an unused use \$stderr\.$#'
+			identifier: closure.unusedUse
+			count: 1
+			path: src/Commands/Remote/SSHBaseCommand.php
+
+		-
+			message: '#^Undefined variable\: \$output$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Commands/Remote/SSHBaseCommand.php
+
+		-
+			message: '#^Undefined variable\: \$stderr$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Commands/Remote/SSHBaseCommand.php
+
+		-
+			message: '#^Method Pantheon\\Terminus\\Commands\\Secret\\Site\\LocalGenerateCommand\:\:localGenerateSecrets\(\) should return Consolidation\\OutputFormatters\\StructuredData\\RowsOfFields but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: src/Commands/Secret/Site/LocalGenerateCommand.php
+
+		-
+			message: '#^Call to an undefined method Pantheon\\Terminus\\Commands\\SecretsHandlingCommand\:\:getConfig\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Commands/SecretsHandlingCommand.php
+
+		-
 			message: '#^Variable \$project on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.variable
 			count: 2
 			path: src/Commands/Self/Plugin/SearchCommand.php
+
+		-
+			message: '#^Call to function compact\(\) contains undefined variable \$upstream_id\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Commands/Site/CreateCommand.php
+
+		-
+			message: '#^Method Pantheon\\Terminus\\Commands\\Site\\CreateCommand\:\:handleGitLabNewInstallation\(\) invoked with 1 parameter, 2 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Commands/Site/CreateCommand.php
+
+		-
+			message: '#^Variable \$helper might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Commands/Site/CreateCommand.php
 
 		-
 			message: '#^Variable \$framework on left side of \?\? always exists and is not nullable\.$#'
@@ -57,12 +129,6 @@ parameters:
 		-
 			message: '#^Variable \$matches in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
-			count: 1
-			path: src/Config/TerminusConfig.php
-
-		-
-			message: '#^Variable \$name on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.variable
 			count: 1
 			path: src/Config/TerminusConfig.php
 
@@ -88,30 +154,6 @@ parameters:
 			path: src/Helpers/CommandCoverageReport.php
 
 		-
-			message: '#^Instantiated class Pantheon\\Terminus\\Helpers\\Utility\\ReflectionClass not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Helpers/Utility/DocBlock.php
-
-		-
-			message: '#^Instantiated class Pantheon\\Terminus\\Helpers\\Utility\\ReflectionFunction not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Helpers/Utility/DocBlock.php
-
-		-
-			message: '#^Instantiated class Pantheon\\Terminus\\Helpers\\Utility\\ReflectionMethod not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Helpers/Utility/DocBlock.php
-
-		-
-			message: '#^Instantiated class Pantheon\\Terminus\\Helpers\\Utility\\ReflectionProperty not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Helpers/Utility/DocBlock.php
-
-		-
 			message: '#^Variable \$from_env_id might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2
@@ -134,12 +176,6 @@ parameters:
 			identifier: return.missing
 			count: 1
 			path: src/Models/SSHKey.php
-
-		-
-			message: '#^Access to an undefined property Pantheon\\Terminus\\Models\\Site\:\:\$framework\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Models/Site.php
 
 		-
 			message: '#^Class Pantheon\\Terminus\\Models\\WorkflowLogsCollection not found\.$#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,11 +5,6 @@
             <directory suffix="Test.php">tests/Functional/</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true" cacheDirectory="reports">
-        <include>
-            <directory suffix="Command.php">src/Commands</directory>
-        </include>
-    </coverage>
     <logging>
         <testdoxXml outputFile="reports/logfile.xml"/>
     </logging>

--- a/src/Collections/Builds.php
+++ b/src/Collections/Builds.php
@@ -22,7 +22,7 @@ class Builds extends TerminusCollection
     /**
      * @var string
      */
-    protected $collected_class = Build::class;
+    protected string $collected_class = Build::class;
 
     /**
      * Fetches model data from API and instantiates its model instances
@@ -34,7 +34,7 @@ class Builds extends TerminusCollection
      *
      * @return \Pantheon\Terminus\Collections\Builds
      */
-    public function fetch(array $builds = []): Builds
+    public function fetch(array $builds = []): static
     {
         foreach ($builds as $id => $model_data) {
             if (!$id && !is_object($model_data)) {

--- a/src/Commands/WorkflowProcessingTrait.php
+++ b/src/Commands/WorkflowProcessingTrait.php
@@ -80,6 +80,7 @@ trait WorkflowProcessingTrait
         int $max_not_found_attempts = 0
     ) {
         $workflow = null;
+        $workflow_description = '';
         if (empty($expected_workflow_description)) {
             $expected_workflow_description = "Sync code on $env_name";
         }

--- a/src/Models/Build.php
+++ b/src/Models/Build.php
@@ -20,9 +20,9 @@ class Build extends TerminusModel
      *
      * @return object $data
      */
-    protected function parseAttributes($data)
+    protected function parseAttributes(object $data): object
     {
-        return [
+        return (object) [
             'id' => $data->id,
             'status' => $data->status,
             'branch' => $data->environment->branch,

--- a/tests/Unit/UnitTestCase.php
+++ b/tests/Unit/UnitTestCase.php
@@ -46,7 +46,6 @@ abstract class UnitTestCase extends TestCase
     {
         $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($propertyName);
-        $property->setAccessible(true);
 
         return $property->getValue($object);
     }
@@ -62,7 +61,6 @@ abstract class UnitTestCase extends TestCase
     {
         $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($propertyName);
-        $property->setAccessible(true);
         $property->setValue($object, $value);
     }
 
@@ -78,7 +76,6 @@ abstract class UnitTestCase extends TestCase
     {
         $reflection = new \ReflectionClass($object);
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($object, $args);
     }


### PR DESCRIPTION
## Summary

- Consolidates `test:quick` into `test:unit` (runs PHPUnit + PHPStan together)
- Adds "Unit Tests & PHPStan" step to `checkout_build` job in CI workflow
- Unit tests now run before phar build, catching type errors early

This ensures static analysis and unit tests run in CI before the longer functional tests, providing faster feedback on type errors discovered during the PHP 8.5 modernization work.

## Test plan

- [ ] CI runs unit tests and PHPStan in checkout_build job
- [ ] Functional tests still run after unit tests pass
- [ ] `composer test:unit` works locally (runs both PHPUnit and PHPStan)

## Dependencies

This PR is based on #2770 and should be rebased/merged after that PR is merged.