### PR TITLE
[DEVX-5146] reload plugins on update

### DIFF
--- a/src/Hooks/PluginReloader.php
+++ b/src/Hooks/PluginReloader.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pantheon\Terminus\Hooks;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class PluginReloader
+ *
+ * Automatically reloads plugins after self:update command completes successfully.
+ *
+ * @package Pantheon\Terminus\Hooks
+ */
+class PluginReloader implements EventSubscriberInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @{@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [ConsoleEvents::TERMINATE => 'reloadPluginsAfterUpdate'];
+    }
+
+    /**
+     * Reload plugins after self:update completes successfully.
+     *
+     * @param ConsoleTerminateEvent $event
+     */
+    public function reloadPluginsAfterUpdate(ConsoleTerminateEvent $event)
+    {
+        $command = $event->getCommand();
+        $exitCode = $event->getExitCode();
+
+        // Only proceed if self:update command completed successfully
+        if ($command && $command->getName() === 'self:update' && $exitCode === 0) {
+            $this->logger->notice('Running plugin reload after successful update...');
+
+            try {
+                // Run the plugin reload command as a separate process
+                $process = new Process(['terminus', 'self:plugin:reload']);
+                $process->setTimeout(300); // 5 minutes timeout
+                $process->run();
+
+                if ($process->isSuccessful()) {
+                    $this->logger->notice('Plugins reloaded successfully.');
+                } else {
+                    $this->logger->warning(
+                        'Plugin reload failed: {error}',
+                        ['error' => $process->getErrorOutput()]
+                    );
+                }
+            } catch (\Exception $e) {
+                $this->logger->warning(
+                    'Could not reload plugins after update: {message}',
+                    ['message' => $e->getMessage()]
+                );
+            }
+        }
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -156,6 +156,7 @@ EOD;
         $update_checker->run();
 
         $container->get('eventDispatcher')->addSubscriber($container->get('Pantheon\Terminus\Hooks\CommandTracker'));
+        $container->get('eventDispatcher')->addSubscriber($container->get('Pantheon\Terminus\Hooks\PluginReloader'));
 
         // We can't use Robo\Application addSelfUpdateCommand because if plugin manager is running it won't be a phar from there.
         if (!empty(\Phar::running())) {
@@ -240,6 +241,9 @@ EOD;
 
         // Command Tracker
         $container->add(CommandTracker::class);
+
+        // Plugin Reloader
+        $container->add('Pantheon\Terminus\Hooks\PluginReloader');
 
         // Install our command cache into the command factory
         $commandCacheDir = $this->getConfig()->get('command_cache_dir');
@@ -337,6 +341,7 @@ EOD;
             'Pantheon\\Terminus\\Hooks\\Authorizer',
             'Pantheon\\Terminus\\Hooks\\CommandTracker',
             'Pantheon\\Terminus\\Hooks\\Interacter',
+            'Pantheon\\Terminus\\Hooks\\PluginReloader',
             'Pantheon\\Terminus\\Hooks\\RoleValidator',
             'Pantheon\\Terminus\\Hooks\\SiteEnvLookup',
             'Pantheon\\Terminus\\Commands\\AliasesCommand',

--- a/templates/homebrew-receipt.twig
+++ b/templates/homebrew-receipt.twig
@@ -18,6 +18,10 @@ class Terminus < Formula
         bin.install "terminus" => "terminus"
     end
 
+    def post_install
+        system bin/"terminus", "self:plugin:reload"
+    end
+
     test do
         system "true"
     end


### PR DESCRIPTION
For both phar-based installs and homebrew installs, plugins are now reloaded after Terminus is updated rather than requiring manual reload.