### PR TITLE
DEVX-7147: Add --custom-domains flag to drush:aliases command

### DIFF
--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -36,6 +36,7 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
      * @option string $type Type of aliases to create: 'php', 'yml' or 'all'.
      * @option string $base Base directory to write .yml aliases.
      * @option string $target Base name to use to generate path to alias files.
+     * @option boolean $custom-domains Use custom domains instead of platform domains for dev, test, and live environments. Uses primary domain if set, otherwise the first custom domain, falling back to platform domain if none configured.
      * @option boolean $db-url Obsolete option included to preserve backwards compatibility. No longer needed.
      *
      * @return string|null
@@ -53,6 +54,7 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
         'base' => '~/.drush',
         'db-url' => true,
         'target' => 'pantheon',
+        'custom-domains' => false,
     ])
     {
         // Be forgiving about the spelling of 'yaml'
@@ -68,6 +70,9 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
         $alias_replacements = $this->getSites($options);
 
         $this->log()->notice("{count} sites found.", ['count' => count($alias_replacements)]);
+
+        // Add with custom domains if requested
+        $alias_replacements = $this->addCustomDomains($alias_replacements, $options);
 
         // Write the alias files (only of the type requested)
         $emitters = $this->getAliasEmitters($options);
@@ -250,5 +255,140 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
     protected function shortenHomePath($message)
     {
         return str_replace($this->getConfig()->get('user_home') ?? '', '~', $message ?? '');
+    }
+
+    /**
+     * Enrich alias replacement data with custom domain URIs when requested.
+     *
+     * @param array $alias_replacements Associative array of site id => alias replacement data
+     * @param array $options Command options
+     * @return array Modified alias replacement data with custom URIs
+     */
+    protected function addCustomDomains($alias_replacements, $options)
+    {
+        // If custom domains feature is not enabled, return unchanged
+        if (empty($options['custom-domains'])) {
+            return $alias_replacements;
+        }
+
+        // Standard environments to generate explicit entries for
+        $standard_envs = ['dev', 'test', 'live'];
+
+        foreach ($alias_replacements as $site_name => &$site_data) {
+            try {
+                $site = $this->sites()->get($site_name);
+                $environments = $site->getEnvironments()->all();
+
+                // Build environments array only for dev, test, live
+                $site_data['environments'] = [];
+
+                foreach ($environments as $env) {
+                    // Only process standard environments
+                    if (!in_array($env->id, $standard_envs)) {
+                        continue;
+                    }
+
+                    $custom_uri = $this->selectBestUri($env);
+
+                    $site_data['environments'][$env->id] = [
+                        'site_name' => $site_data['site_name'],
+                        'env_name' => $env->id,
+                        'env_label' => $env->id,
+                        'site_id' => $site_data['site_id'],
+                        'custom_uri' => $custom_uri,
+                    ];
+                }
+
+            } catch (\Exception $e) {
+                $this->log()->warning(
+                    "Could not fetch domains for site {site}: {error}",
+                    [
+                        'site' => $site_name,
+                        'error' => $e->getMessage(),
+                    ]
+                );
+            }
+        }
+
+        return $alias_replacements;
+    }
+
+    /**
+     * Select the best URI for an environment.
+     *
+     * Priority:
+     * 1. Primary domain (if configured and not a platform domain)
+     * 2. First custom domain
+     * 3. Platform domain (fallback)
+     *
+     * @param \Pantheon\Terminus\Models\Environment $environment
+     * @return string The selected URI
+     */
+    protected function selectBestUri($environment)
+    {
+        try {
+            $domains = $environment->getDomains()->all();
+
+            // Check for primary domain first
+            foreach ($domains as $domain) {
+                if ($domain->get('primary') === true) {
+                    $domain_name = $domain->id;
+                    if (!$this->isPlatformDomain($domain_name)) {
+                        return $domain_name;
+                    }
+                }
+            }
+
+            // Look for first custom domain
+            foreach ($domains as $domain) {
+                $domain_name = $domain->id;
+                $domain_type = $domain->get('type');
+
+                if ($domain_type === 'custom' || !$this->isPlatformDomain($domain_name)) {
+                    return $domain_name;
+                }
+            }
+        } catch (\Exception $e) {
+            $this->log()->debug(
+                "Could not fetch domains for environment {env}: {error}",
+                [
+                    'env' => $environment->id,
+                    'error' => $e->getMessage(),
+                ]
+            );
+        }
+
+        // Fallback to platform domain
+        return $this->getPlatformDomain($environment);
+    }
+
+    /**
+     * Check if a domain is a Pantheon platform domain.
+     *
+     * @param string $domain
+     * @return bool
+     */
+    protected function isPlatformDomain($domain)
+    {
+        return (
+            strpos($domain, '.pantheonsite.io') !== false ||
+            strpos($domain, '.pantheon.io') !== false ||
+            strpos($domain, '.gotpantheon.com') !== false
+        );
+    }
+
+    /**
+     * Get the platform domain for an environment.
+     *
+     * @param \Pantheon\Terminus\Models\Environment $environment
+     * @return string
+     */
+    protected function getPlatformDomain($environment)
+    {
+        $site = $environment->getSite();
+        $env_label = $environment->id;
+        $site_name = $site->get('name');
+
+        return "{$env_label}-{$site_name}.pantheonsite.io";
     }
 }

--- a/src/Helpers/AliasEmitters/AliasesDrushRcBase.php
+++ b/src/Helpers/AliasEmitters/AliasesDrushRcBase.php
@@ -23,9 +23,29 @@ abstract class AliasesDrushRcBase implements
     protected function getAliasContents(array $alias_replacements): string
     {
         $output = Template::process('header.aliases.drushrc.php.twig');
+
         foreach ($alias_replacements as $replacements) {
-            $this->logger->debug('Creating alias: ' . print_r($replacements, true));
-            $output .= Template::process('fragment.aliases.drushrc.php.twig', $replacements) . PHP_EOL;
+            // If we have individual environments (custom domains enabled), render each one
+            if (isset($replacements['environments']) && !empty($replacements['environments'])) {
+                foreach ($replacements['environments'] as $env_data) {
+                    $this->logger->debug('Creating alias: ' . print_r($env_data, true));
+                    $output .= Template::process('fragment.aliases.drushrc.php.twig', $env_data) . PHP_EOL;
+                }
+
+                // Add wildcard pattern at the end for multidev environments
+                $wildcard_data = [
+                    'site_name' => $replacements['site_name'],
+                    'env_name' => '*',
+                    'env_label' => '${env-name}',
+                    'site_id' => $replacements['site_id'],
+                ];
+                $this->logger->debug('Creating wildcard alias: ' . print_r($wildcard_data, true));
+                $output .= Template::process('fragment.aliases.drushrc.php.twig', $wildcard_data) . PHP_EOL;
+            } else {
+                // Otherwise, use the wildcard pattern only (backward compatible)
+                $this->logger->debug('Creating alias: ' . print_r($replacements, true));
+                $output .= Template::process('fragment.aliases.drushrc.php.twig', $replacements) . PHP_EOL;
+            }
         }
 
         return $output;

--- a/src/Helpers/AliasEmitters/DrushSitesYmlEmitter.php
+++ b/src/Helpers/AliasEmitters/DrushSitesYmlEmitter.php
@@ -100,6 +100,27 @@ class DrushSitesYmlEmitter implements AliasEmitterInterface
      */
     protected function getAliasFragment(array $replacements)
     {
+        $fragments = [];
+
+        // If we have individual environments (custom domains enabled), render each one
+        if (isset($replacements['environments']) && !empty($replacements['environments'])) {
+            foreach ($replacements['environments'] as $env_data) {
+                $fragments[] = Template::process('fragment.site.yml.twig', $env_data);
+            }
+
+            // Add wildcard pattern at the end for multidev environments
+            $wildcard_data = [
+                'site_name' => $replacements['site_name'],
+                'env_name' => '*',
+                'env_label' => '${env-name}',
+                'site_id' => $replacements['site_id'],
+            ];
+            $fragments[] = Template::process('fragment.site.yml.twig', $wildcard_data);
+
+            return implode("\n", $fragments);
+        }
+
+        // Otherwise, use the wildcard pattern only (backward compatible)
         return Template::process('fragment.site.yml.twig', $replacements);
     }
 

--- a/templates/aliases/fragment.aliases.drushrc.php.twig
+++ b/templates/aliases/fragment.aliases.drushrc.php.twig
@@ -1,5 +1,5 @@
   $aliases['{{site_name}}.{{env_name}}'] = array(
-    'uri' => '{{env_label}}-{{site_name}}.pantheonsite.io',
+    'uri' => '{% if custom_uri is defined %}{{custom_uri}}{% else %}{{env_label}}-{{site_name}}.pantheonsite.io{% endif %}',
     'remote-host' => 'appserver.{{env_label}}.{{site_id}}.drush.in',
     'remote-user' => '{{env_label}}.{{site_id}}',
     'ssh-options' => '-p 2222 -o "AddressFamily inet"',

--- a/templates/aliases/fragment.site.yml.twig
+++ b/templates/aliases/fragment.site.yml.twig
@@ -2,7 +2,8 @@
   host: appserver.{{env_label}}.{{site_id}}.drush.in
   paths:
     files: files
-  uri: {{env_label}}-{{site_name}}.pantheonsite.io
+  uri: {% if custom_uri is defined %}{{custom_uri}}{% else %}{{env_label}}-{{site_name}}.pantheonsite.io{% endif %}
+
   user: {{env_label}}.{{site_id}}
   ssh:
     options: '-p 2222 -o "AddressFamily inet"'

--- a/tests/Functional/AliasesCommandTest.php
+++ b/tests/Functional/AliasesCommandTest.php
@@ -111,5 +111,26 @@ class AliasesCommandTest extends TerminusTestBase
     tty: false
 EOF;
         $this->assertEquals($expected_drush_9_site_alias, $drush_9_site_alias_in_file);
+
+        // Test --custom-domains flag
+        $this->terminus(sprintf('drush:aliases --only=%s --custom-domains', $this->getSiteName()));
+
+        // Re-read the Drush 9 site alias file to check for custom domain entries
+        $drush_9_site_alias_with_custom_domains = trim(file_get_contents($drush_9_site_alias_file_path));
+
+        // The output should now contain explicit entries for dev, test, and live environments
+        // when custom domains are configured (and still contain the wildcard)
+        $this->assertTrue(
+            false !== strpos($drush_9_site_alias_with_custom_domains, "'dev':") ||
+            false !== strpos($drush_9_site_alias_with_custom_domains, "'live':") ||
+            false !== strpos($drush_9_site_alias_with_custom_domains, "'test':"),
+            'Drush 9 alias file with --custom-domains should contain explicit environment entries (dev, test, or live)'
+        );
+
+        // Wildcard entry should still be present
+        $this->assertTrue(
+            false !== strpos($drush_9_site_alias_with_custom_domains, "'*':"),
+            'Drush 9 alias file with --custom-domains should still contain wildcard entry'
+        );
     }
 }


### PR DESCRIPTION
Resolves #2481

This pull request adds support for custom domain URIs in Drush alias generation. When generating Drush aliases, Terminus now has the option to use configured custom domains instead of hardcoded `pantheonsite.io` platform domains for the dev, test, and live environments.

A new `--custom-domains` flag has been added to the `drush:aliases` command. When enabled, the command fetches domain information for each environment and selects the appropriate URI using the following priority: (1) primary domain if configured and not a platform domain, (2) first custom domain found, or (3) platform domain as fallback. The implementation generates explicit alias entries for the standard dev, test, and live environments with their respective custom domains, while maintaining a wildcard entry for multidev environments to ensure compatibility with dynamically-created environments. This approach works for both Drush 8 (PHP array format) and Drush 9+ (YAML format) alias files.

When the `--custom-domains` flag is not specified, the command behaves exactly as before, generating only wildcard entries with platform domains. This ensures complete backward compatibility for existing workflows and scripts.