### PR TITLE
[NCX-46]  Two-part Config Flag setup for Requiring Orgs During Site Creation

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -54,7 +54,8 @@ TERMINUS_ORG:  null
 TERMINUS_COMMAND_SITE_OPTIONS_REGION: null
 
 # Feature Flags
-TERMINUS_SITE_CREATE_REQUIRE_ORG: false
+TERMINUS_SITE_CREATE_WARN_ORG: false    # Phase 1: Show deprecation warning
+TERMINUS_SITE_CREATE_REQUIRE_ORG: false # Phase 2: Block site creation
 
 # Package Settings
 TERMINUS_BREW_TAP:               '*** TBD ***'

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -53,6 +53,9 @@ TERMINUS_ORG:  null
 # Region
 TERMINUS_COMMAND_SITE_OPTIONS_REGION: null
 
+# Feature Flags
+TERMINUS_SITE_CREATE_REQUIRE_ORG: false
+
 # Package Settings
 TERMINUS_BREW_TAP:               '*** TBD ***'
 TERMINUS_BREW_PACKAGE:           'pantheon-systems/external/terminus'

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -28,11 +28,10 @@ class CreateCommand extends SiteCommand
      * @param string $site_name Site name
      * @param string $label Site label
      * @param string $upstream_id Upstream name or UUID
-     * @option org Organization name, label, or ID
+     * @option org Organization name, label, or ID (recommended; will be required in the future)
      * @option region Specify the service region where the site should be
      *   created. See documentation for valid regions.
      *
-     * @usage <site> <label> <upstream> Creates a new site named <site>, human-readably labeled <label>, using code from <upstream>.
      * @usage <site> <label> <upstream> --org=<org> Creates a new site named <site>, human-readably labeled <label>, using code from <upstream>, associated with <organization>.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
@@ -44,6 +43,16 @@ class CreateCommand extends SiteCommand
     {
         if ($this->sites()->nameIsTaken($site_name)) {
             throw new TerminusException('The site name {site_name} is already taken.', compact('site_name'));
+        }
+
+        // Warn about org requirement when feature flag is enabled.
+        if ($this->config->get('site_create_require_org') && empty($options['org'])) {
+            $this->log()->warning(
+                'Creating sites without an organization will be deprecated. ' .
+                'In the future, the --org parameter will be required. ' .
+                'Please update your scripts to include --org. ' .
+                'Learn more: https://docs.pantheon.io/guides/account-mgmt/workspace-sites-teams/workspaces'
+            );
         }
 
         $workflow_options = [

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -45,14 +45,19 @@ class CreateCommand extends SiteCommand
             throw new TerminusException('The site name {site_name} is already taken.', compact('site_name'));
         }
 
-        // Warn about org requirement when feature flag is enabled.
-        if ($this->config->get('site_create_require_org') && empty($options['org'])) {
+        // Phase 1: Warn about org requirement when feature flag is enabled.
+        if ($this->config->get('site_create_warn_org') && empty($options['org'])) {
             $this->log()->warning(
                 'Creating sites without an organization will be deprecated. ' .
                 'In the future, the --org parameter will be required. ' .
                 'Please update your scripts to include --org. ' .
                 'Learn more: https://docs.pantheon.io/guides/account-mgmt/workspace-sites-teams/workspaces'
             );
+        }
+
+        // Phase 2: Require org when enforcement flag is enabled.
+        if ($this->config->get('site_create_require_org') && empty($options['org'])) {
+            throw new TerminusException('An organization must be defined to create a site.');
         }
 
         $workflow_options = [

--- a/src/Hooks/Interacter.php
+++ b/src/Hooks/Interacter.php
@@ -180,6 +180,10 @@ class Interacter implements ConfigAwareInterface, ContainerAwareInterface, Sessi
                 }
                 $functionName = 'get' . ucfirst($type) . 'List';
                 if (method_exists($this, $functionName)) {
+                    // Override allow_empty for org if feature flag requires it.
+                    if ($type === 'organization' && $this->getConfig()->get('site_create_require_org')) {
+                        $allow_empty = false;
+                    }
                     return $io->choice($description, $this->$functionName($allow_empty));
                 } else {
                     throw new TerminusException('Unknown type: {type}', ['type' => $type]);

--- a/tests/Functional/SiteCommandsTest.php
+++ b/tests/Functional/SiteCommandsTest.php
@@ -165,10 +165,10 @@ class SiteCommandsTest extends TerminusTestBase
      * @group site
      * @group short
      */
-    public function testSiteCreateWarnsWhenOrgMissingAndFlagEnabled()
+    public function testSiteCreateWarnsWhenOrgMissingAndWarnFlagEnabled()
     {
-        if (!getenv('TERMINUS_SITE_CREATE_REQUIRE_ORG')) {
-            $this->markTestSkipped('TERMINUS_SITE_CREATE_REQUIRE_ORG not enabled');
+        if (!getenv('TERMINUS_SITE_CREATE_WARN_ORG')) {
+            $this->markTestSkipped('TERMINUS_SITE_CREATE_WARN_ORG not enabled');
         }
 
         $siteName = uniqid('test-site-');
@@ -184,6 +184,32 @@ class SiteCommandsTest extends TerminusTestBase
         );
         $this->assertStringContainsString(
             '--org parameter will be required',
+            $output
+        );
+    }
+
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Site\CreateCommand
+     *
+     * @group site
+     * @group short
+     */
+    public function testSiteCreateRequiresOrgWhenRequireFlagEnabled()
+    {
+        if (!getenv('TERMINUS_SITE_CREATE_REQUIRE_ORG')) {
+            $this->markTestSkipped('TERMINUS_SITE_CREATE_REQUIRE_ORG not enabled');
+        }
+
+        $siteName = uniqid('test-site-');
+        $output = $this->terminus(
+            sprintf('site:create %s %s drupal9', $siteName, $siteName),
+            [],
+            false
+        );
+
+        $this->assertStringContainsString(
+            'An organization must be defined to create a site',
             $output
         );
     }

--- a/tests/Functional/SiteCommandsTest.php
+++ b/tests/Functional/SiteCommandsTest.php
@@ -160,6 +160,36 @@ class SiteCommandsTest extends TerminusTestBase
 
     /**
      * @test
+     * @covers \Pantheon\Terminus\Commands\Site\CreateCommand
+     *
+     * @group site
+     * @group short
+     */
+    public function testSiteCreateWarnsWhenOrgMissingAndFlagEnabled()
+    {
+        if (!getenv('TERMINUS_SITE_CREATE_REQUIRE_ORG')) {
+            $this->markTestSkipped('TERMINUS_SITE_CREATE_REQUIRE_ORG not enabled');
+        }
+
+        $siteName = uniqid('test-site-');
+        $output = $this->terminus(
+            sprintf('site:create %s %s drupal9', $siteName, $siteName),
+            [],
+            false
+        );
+
+        $this->assertStringContainsString(
+            'Creating sites without an organization will be deprecated',
+            $output
+        );
+        $this->assertStringContainsString(
+            '--org parameter will be required',
+            $output
+        );
+    }
+
+    /**
+     * @test
      * @covers \Pantheon\Terminus\Commands\Site\LabelCommand
      *
      * @group site


### PR DESCRIPTION
## Summary
Adds two feature flags to support the gradual rollout of requiring `--org` for site creation. This helps customers migrate away from personal workspace site creation before it's fully deprecated platform-wide.

## Background
Personal workspaces are being deprecated. When that happens, all site creation will require an organization. These flags let us warn customers first, then enforce the requirement when the platform is ready.

## How It Works

**Flag 1: `TERMINUS_SITE_CREATE_WARN_ORG`** (the gentle nudge)
- Shows a deprecation warning when someone runs `site:create` without `--org`
- Site creation still works
- Gives customers time to update their scripts and automation

**Flag 2: `TERMINUS_SITE_CREATE_REQUIRE_ORG`** (the enforcement)
- Blocks site creation when `--org` is missing in non-interactive mode
- In interactive mode, prompts user to select an organization (removes 'None' option via Interacter)
- Returns a clear error message for automation/scripts
- Turns on when we're ready to enforce platform-wide

## Why Two Flags?
Having separate flags means we can roll this out in phases instead of breaking everyone's scripts at once. We can turn on warnings early while customers update their automation, then flip the enforcement flag later when the API is ready to reject orgless sites.

## Implementation
- [config/constants.yml](config/constants.yml): Added both feature flags
- [src/Commands/Site/CreateCommand.php](src/Commands/Site/CreateCommand.php): Check both flags independently
- [src/Hooks/Interacter.php](src/Hooks/Interacter.php): Wired to remove 'None' option when enforcement flag is enabled
- [tests/Functional/SiteCommandsTest.php](tests/Functional/SiteCommandsTest.php): Tests for warning behavior and blocking behavior

## Rollout Plan
1. Turn on warnings with coordinated customer communication
2. Give customers time to update scripts and CI pipelines  
3. Turn on enforcement when API is ready to block orgless creation globally
4. API enforcement will catch all Terminus versions (old and new)

## Important Notes
- No breaking changes to command signature (still using options, not positional params)
- Customers with automation need to add `--org` to their scripts before enforcement
- Interactive users will get an org selection prompt during Phase 2 (no 'None' option)
- API-level enforcement will handle customers on older Terminus versions
- Coordinated with PDE for customer communications

## Tests
- `testSiteCreateWarnsWhenOrgMissingAndWarnFlagEnabled`: Warning shows up correctly
- `testSiteCreateRequiresOrgWhenRequireFlagEnabled`: Blocking works as expected

## References
- [Jira Ticket](https://getpantheon.atlassian.net/browse/NCX-46)
- [Slack Convo](https://pantheon.slack.com/archives/C024NA0Q1TJ/p1770402864208339)