### PR TITLE
Handle non-JSON API responses on 2xx without fataling

### DIFF
--- a/src/Collections/Workflows.php
+++ b/src/Collections/Workflows.php
@@ -123,6 +123,13 @@ class Workflows extends APICollection implements SessionAwareInterface
                 ['error' => $results->getStatusCodeReason()]
             );
         }
+        if (!is_object($results->getData()) || !isset($results->getData()->id)) {
+            throw new TerminusException(
+                'Workflow creation succeeded (HTTP {status_code}) but the response '
+                . 'was not a valid workflow object.',
+                ['status_code' => $results->getStatusCode()]
+            );
+        }
         $nickname = \uniqid(__CLASS__ . "-");
         $this->getContainer()->add($nickname, $this->collected_class)
             ->addArguments([

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -427,6 +427,7 @@ class Request implements
         $statusCode = $response->getStatusCode();
         $headers = $response->getHeaders();
         $decoded_body = null;
+        $json_decode_failed = false;
 
         // Don't attempt to decode JSON if the body is empty.
         if (!empty($body)) {
@@ -438,9 +439,28 @@ class Request implements
                     JSON_THROW_ON_ERROR
                 );
             } catch (\JsonException $jsonException) {
-                $this->logger->debug('json_decode exception: {message}', [
-                    'message' => $jsonException->getMessage()
-                ]);
+                if ($statusCode >= 200 && $statusCode < 300) {
+                    // On 2xx responses, non-JSON is an API contract violation.
+                    // Substitute an empty object to prevent downstream fatals
+                    // from code that expects to access properties on the result.
+                    $this->logger->warning(
+                        'API returned non-JSON response body for {uri} (HTTP {status_code}). '
+                        . 'Content-Type: {content_type}. Body preview: {body_preview}',
+                        [
+                            'uri' => $uri,
+                            'status_code' => $statusCode,
+                            'content_type' => $response->getHeaderLine('Content-Type'),
+                            'body_preview' => substr($body, 0, 200),
+                        ]
+                    );
+                    $decoded_body = new \stdClass();
+                    $json_decode_failed = true;
+                } else {
+                    // For error responses, keep raw string — callers use it for error messages.
+                    $this->logger->debug('json_decode exception: {message}', [
+                        'message' => $jsonException->getMessage()
+                    ]);
+                }
             }
         }
 
@@ -456,12 +476,16 @@ class Request implements
             }
         }
 
-        return new RequestOperationResult([
+        $result = new RequestOperationResult([
             'data' => $decoded_body ?? $body,
             'headers' => $headers,
             'status_code' => $statusCode,
             'status_code_reason' => $response->getReasonPhrase(),
         ]);
+        if ($json_decode_failed) {
+            $result->setJsonDecodeFailed(true);
+        }
+        return $result;
     }
 
     /**

--- a/src/Request/RequestOperationResult.php
+++ b/src/Request/RequestOperationResult.php
@@ -23,6 +23,10 @@ final class RequestOperationResult implements \ArrayAccess
 
     private string $status_code_reason;
 
+    /**
+     * @var bool
+     */
+    private bool $json_decode_failed = false;
 
     /**
      * RequestOperationResult constructor.
@@ -169,5 +173,23 @@ final class RequestOperationResult implements \ArrayAccess
     public function isError(): bool
     {
         return !(bool) preg_match('/^2\d{2}$/', $this->getStatusCode());
+    }
+
+    /**
+     * Whether the response body failed to decode as JSON.
+     *
+     * @return bool
+     */
+    public function isJsonDecodeFailed(): bool
+    {
+        return $this->json_decode_failed;
+    }
+
+    /**
+     * @param bool $failed
+     */
+    public function setJsonDecodeFailed(bool $failed): void
+    {
+        $this->json_decode_failed = $failed;
     }
 }


### PR DESCRIPTION
## Summary

- When the API returns a non-JSON body on a 2xx response, Terminus now substitutes an empty `stdClass` instead of letting the raw string flow through to downstream code that expects object properties. This prevents fatals from `->property` access on strings and garbage data from `(array)` casting strings.
- The fix is centralized in `Request::request()` so all callers are protected automatically. A warning is logged with diagnostics (URI, status code, Content-Type, body preview) when this occurs.
- Added a `jsonDecodeFailed` flag to `RequestOperationResult` for callers that need to distinguish a JSON decode failure from a legitimately empty response.
- Added an explicit guard in `Workflows::create()` before accessing `getData()->id` to throw a clear error message instead of a cryptic null property access.

## Test plan

- [x] Existing test suite passes (54 tests, 1028 assertions)
- [ ] Verify normal API behavior is unchanged (e.g. `terminus site:list`, `terminus env:info`)
- [ ] Verify that when a non-JSON 2xx response occurs, a warning is logged (visible with `-vvv`) and the command degrades gracefully instead of fataling