### PR TITLE
[SITE-5394] Add Elasticsearch support with unified search commands

### DIFF
--- a/src/Commands/Search/DisableCommand.php
+++ b/src/Commands/Search/DisableCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Search;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+/**
+ * Class DisableCommand
+ * @package Pantheon\Terminus\Commands\Search
+ */
+class DisableCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+    use WorkflowProcessingTrait;
+
+    /**
+     * Disables search indexing add-on for a site.
+     *
+     * @authorize
+     * @interact
+     *
+     * @command search:disable
+     *
+     * @param string $site_id Site name
+     * @param array $options
+     * @option string $flavor [solr|elasticsearch] Search engine flavor to disable. Defaults to 'solr' for Drupal sites and 'elasticsearch' for WordPress sites.
+     *
+     * @usage <site> Disables search indexing for <site> (auto-detects flavor).
+     * @usage <site> --flavor=solr Disables Solr indexing for <site>.
+     * @usage <site> --flavor=elasticsearch Disables Elasticsearch for <site>.
+     *
+     * @throws TerminusException
+     */
+    public function disable($site_id, array $options = ['flavor' => null])
+    {
+        $site = $this->getSiteById($site_id);
+        $framework = $site->getFramework();
+
+        // Determine flavor
+        $flavor = $this->determineFlavor($options['flavor'], $framework);
+
+        // Disable the appropriate search engine
+        if ($flavor === 'elasticsearch') {
+            $workflow = $site->getElasticsearch()->disable();
+            $this->log()->notice('Disabling Elasticsearch for {site}...', ['site' => $site_id]);
+        } else {
+            $workflow = $site->getSolr()->disable();
+            $this->log()->notice('Disabling Solr for {site}...', ['site' => $site_id]);
+        }
+
+        $this->processWorkflow($workflow);
+        $this->log()->notice($workflow->getMessage());
+    }
+
+    /**
+     * Determines the search flavor to use
+     *
+     * @param string|null $requested_flavor The flavor requested by the user
+     * @param \Pantheon\Terminus\Helpers\Utility\SiteFramework $framework The site framework
+     * @return string The flavor to use ('solr' or 'elastic')
+     */
+    private function determineFlavor($requested_flavor, $framework)
+    {
+        if ($requested_flavor !== null) {
+            $flavor = strtolower($requested_flavor);
+            if (!in_array($flavor, ['solr', 'elasticsearch'])) {
+                throw new TerminusException(
+                    'Invalid flavor "{flavor}". Must be either "solr" or "elasticsearch".',
+                    ['flavor' => $requested_flavor]
+                );
+            }
+            return $flavor;
+        }
+
+        // Auto-detect based on framework
+        if ($framework->isWordpressFramework()) {
+            return 'elasticsearch';
+        }
+
+        return 'solr'; // Default for Drupal and others
+    }
+}

--- a/src/Commands/Search/DisableCommand.php
+++ b/src/Commands/Search/DisableCommand.php
@@ -16,6 +16,7 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
 {
     use SiteAwareTrait;
     use WorkflowProcessingTrait;
+    use SearchFlavorTrait;
 
     /**
      * Disables search indexing add-on for a site.
@@ -54,33 +55,5 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
 
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());
-    }
-
-    /**
-     * Determines the search flavor to use
-     *
-     * @param string|null $requested_flavor The flavor requested by the user
-     * @param \Pantheon\Terminus\Helpers\Utility\SiteFramework $framework The site framework
-     * @return string The flavor to use ('solr' or 'elastic')
-     */
-    private function determineFlavor($requested_flavor, $framework)
-    {
-        if ($requested_flavor !== null) {
-            $flavor = strtolower($requested_flavor);
-            if (!in_array($flavor, ['solr', 'elasticsearch'])) {
-                throw new TerminusException(
-                    'Invalid flavor "{flavor}". Must be either "solr" or "elasticsearch".',
-                    ['flavor' => $requested_flavor]
-                );
-            }
-            return $flavor;
-        }
-
-        // Auto-detect based on framework
-        if ($framework->isWordpressFramework()) {
-            return 'elasticsearch';
-        }
-
-        return 'solr'; // Default for Drupal and others
     }
 }

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -56,7 +56,22 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
         }
 
         $this->processWorkflow($workflow);
-        $this->log()->notice($workflow->getMessage());
+
+        // Display custom success message with proper capitalization
+        if ($workflow->isSuccessful()) {
+            if ($flavor === 'elasticsearch') {
+                $this->log()->notice('Enabled Elasticsearch for {site}.', ['site' => $site_id]);
+                $this->log()->notice(
+                    'Read the documentation to complete the Elasticsearch configuration for your site: ' .
+                    'https://docs.pantheon.io/pantheon-search'
+                );
+            } else {
+                $this->log()->notice('Enabled Solr for {site}.', ['site' => $site_id]);
+            }
+        } else {
+            // If workflow failed, show the API error message
+            $this->log()->notice($workflow->getMessage());
+        }
     }
 
     /**

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -16,6 +16,7 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
 {
     use SiteAwareTrait;
     use WorkflowProcessingTrait;
+    use SearchFlavorTrait;
 
     /**
      * Enables search indexing add-on for a site.
@@ -65,34 +66,6 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
                 'https://docs.pantheon.io/pantheon-search'
             );
         }
-    }
-
-    /**
-     * Determines the search flavor to use
-     *
-     * @param string|null $requested_flavor The flavor requested by the user
-     * @param \Pantheon\Terminus\Helpers\Utility\SiteFramework $framework The site framework
-     * @return string The flavor to use ('solr' or 'elastic')
-     */
-    private function determineFlavor($requested_flavor, $framework)
-    {
-        if ($requested_flavor !== null) {
-            $flavor = strtolower($requested_flavor);
-            if (!in_array($flavor, ['solr', 'elasticsearch'])) {
-                throw new TerminusException(
-                    'Invalid flavor "{flavor}". Must be either "solr" or "elasticsearch".',
-                    ['flavor' => $requested_flavor]
-                );
-            }
-            return $flavor;
-        }
-
-        // Auto-detect based on framework
-        if ($framework->isWordpressFramework()) {
-            return 'elasticsearch';
-        }
-
-        return 'solr'; // Default for Drupal and others
     }
 
     /**

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -106,8 +106,10 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
     private function validateFlavorForFramework($flavor, $framework, $site)
     {
         // Block Drupal sites from using Elasticsearch
-        if ($flavor === 'elasticsearch' &&
-            ($framework->isDrupal7Framework() || $framework->isDrupal8Framework())) {
+        if (
+            $flavor === 'elasticsearch' &&
+            ($framework->isDrupal7Framework() || $framework->isDrupal8Framework())
+        ) {
             throw new TerminusException(
                 'Elasticsearch is not supported for Drupal sites. Please use Solr instead.'
             );

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -105,15 +105,7 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
             );
         }
 
-        // Check WordPress sites have Elasticsearch entitlement
-        if ($flavor === 'elasticsearch' && $framework->isWordpressFramework()) {
-            $elasticsearch_feature = $site->getFeature('elasticsearch');
-            if ($elasticsearch_feature === null || $elasticsearch_feature === false) {
-                throw new TerminusException(
-                    'This site does not have Elasticsearch enabled. ' .
-                    'Please contact support or use --flavor=solr for Solr indexing.'
-                );
-            }
-        }
+        // WordPress sites: Let the API workflow validate Elasticsearch entitlement
+        // The workflow will fail with an appropriate error if not entitled
     }
 }

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Search;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+/**
+ * Class EnableCommand
+ * @package Pantheon\Terminus\Commands\Search
+ */
+class EnableCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+    use WorkflowProcessingTrait;
+
+    /**
+     * Enables search indexing add-on for a site.
+     *
+     * @authorize
+     * @interact
+     *
+     * @command search:enable
+     *
+     * @param string $site_id Site name
+     * @param array $options
+     * @option string $flavor [solr|elasticsearch] Search engine flavor to enable. Defaults to 'solr' for Drupal sites and 'elasticsearch' for WordPress sites.
+     *
+     * @usage <site> Enables search indexing for <site> (auto-detects flavor).
+     * @usage <site> --flavor=solr Enables Solr indexing for <site>.
+     * @usage <site> --flavor=elasticsearch Enables Elasticsearch for <site>.
+     *
+     * @throws TerminusException
+     */
+    public function enable($site_id, array $options = ['flavor' => null])
+    {
+        $site = $this->getSiteById($site_id);
+        $framework = $site->getFramework();
+
+        // Determine flavor
+        $flavor = $this->determineFlavor($options['flavor'], $framework);
+
+        // Validate flavor for framework
+        $this->validateFlavorForFramework($flavor, $framework, $site);
+
+        // Enable the appropriate search engine
+        if ($flavor === 'elasticsearch') {
+            $workflow = $site->getElasticsearch()->enable();
+            $this->log()->notice('Enabling Elasticsearch for {site}...', ['site' => $site_id]);
+        } else {
+            $workflow = $site->getSolr()->enable();
+            $this->log()->notice('Enabling Solr for {site}...', ['site' => $site_id]);
+        }
+
+        $this->processWorkflow($workflow);
+        $this->log()->notice($workflow->getMessage());
+    }
+
+    /**
+     * Determines the search flavor to use
+     *
+     * @param string|null $requested_flavor The flavor requested by the user
+     * @param \Pantheon\Terminus\Helpers\Utility\SiteFramework $framework The site framework
+     * @return string The flavor to use ('solr' or 'elastic')
+     */
+    private function determineFlavor($requested_flavor, $framework)
+    {
+        if ($requested_flavor !== null) {
+            $flavor = strtolower($requested_flavor);
+            if (!in_array($flavor, ['solr', 'elasticsearch'])) {
+                throw new TerminusException(
+                    'Invalid flavor "{flavor}". Must be either "solr" or "elasticsearch".',
+                    ['flavor' => $requested_flavor]
+                );
+            }
+            return $flavor;
+        }
+
+        // Auto-detect based on framework
+        if ($framework->isWordpressFramework()) {
+            return 'elasticsearch';
+        }
+
+        return 'solr'; // Default for Drupal and others
+    }
+
+    /**
+     * Validates that the flavor is compatible with the framework
+     *
+     * @param string $flavor The search flavor
+     * @param \Pantheon\Terminus\Helpers\Utility\SiteFramework $framework The site framework
+     * @param \Pantheon\Terminus\Models\Site $site The site model
+     * @throws TerminusException
+     */
+    private function validateFlavorForFramework($flavor, $framework, $site)
+    {
+        // Block Drupal sites from using Elasticsearch
+        if ($flavor === 'elasticsearch' &&
+            ($framework->isDrupal7Framework() || $framework->isDrupal8Framework())) {
+            throw new TerminusException(
+                'Elasticsearch is not supported for Drupal sites. Please use Solr instead.'
+            );
+        }
+
+        // Check WordPress sites have Elasticsearch entitlement
+        if ($flavor === 'elasticsearch' && $framework->isWordpressFramework()) {
+            $elasticsearch_feature = $site->getFeature('elasticsearch');
+            if ($elasticsearch_feature === null || $elasticsearch_feature === false) {
+                throw new TerminusException(
+                    'This site does not have Elasticsearch enabled. ' .
+                    'Please contact support or use --flavor=solr for Solr indexing.'
+                );
+            }
+        }
+    }
+}

--- a/src/Commands/Search/EnableCommand.php
+++ b/src/Commands/Search/EnableCommand.php
@@ -56,21 +56,14 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
         }
 
         $this->processWorkflow($workflow);
+        $this->log()->notice($workflow->getMessage());
 
-        // Display custom success message with proper capitalization
-        if ($workflow->isSuccessful()) {
-            if ($flavor === 'elasticsearch') {
-                $this->log()->notice('Enabled Elasticsearch for {site}.', ['site' => $site_id]);
-                $this->log()->notice(
-                    'Read the documentation to complete the Elasticsearch configuration for your site: ' .
-                    'https://docs.pantheon.io/pantheon-search'
-                );
-            } else {
-                $this->log()->notice('Enabled Solr for {site}.', ['site' => $site_id]);
-            }
-        } else {
-            // If workflow failed, show the API error message
-            $this->log()->notice($workflow->getMessage());
+        // Provide documentation link for successful Elasticsearch enablement
+        if ($flavor === 'elasticsearch' && $workflow->isSuccessful()) {
+            $this->log()->notice(
+                'Read the documentation to complete the Elasticsearch configuration for your site: ' .
+                'https://docs.pantheon.io/pantheon-search'
+            );
         }
     }
 

--- a/src/Commands/Search/SearchFlavorTrait.php
+++ b/src/Commands/Search/SearchFlavorTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Search;
+
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Helpers\Utility\SiteFramework;
+
+/**
+ * Trait SearchFlavorTrait
+ * @package Pantheon\Terminus\Commands\Search
+ */
+trait SearchFlavorTrait
+{
+    /**
+     * Determines the search flavor to use
+     *
+     * @param string|null $requested_flavor The flavor requested by the user
+     * @param SiteFramework $framework The site framework
+     * @return string The flavor to use ('solr' or 'elasticsearch')
+     * @throws TerminusException
+     */
+    private function determineFlavor($requested_flavor, SiteFramework $framework)
+    {
+        if ($requested_flavor !== null) {
+            $flavor = strtolower($requested_flavor);
+            if (!in_array($flavor, ['solr', 'elasticsearch'])) {
+                throw new TerminusException(
+                    'Invalid flavor "{flavor}". Must be either "solr" or "elasticsearch".',
+                    ['flavor' => $requested_flavor]
+                );
+            }
+            return $flavor;
+        }
+
+        // Auto-detect based on framework
+        if ($framework->isWordpressFramework()) {
+            return 'elasticsearch';
+        }
+
+        return 'solr'; // Default for Drupal and others
+    }
+}

--- a/src/Commands/Solr/DisableCommand.php
+++ b/src/Commands/Solr/DisableCommand.php
@@ -27,9 +27,17 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_id Site name
      *
      * @usage <site> Disables Solr add-on for <site>.
+     *
+     * @deprecated Use 'search:disable --flavor=solr' instead. This command will be removed in a future version.
      */
     public function disable($site_id)
     {
+        $this->log()->warning(
+            'The "solr:disable" command is deprecated. ' .
+            'Please use "search:disable --flavor=solr" instead. ' .
+            'This command will be removed in a future version of Terminus.'
+        );
+
         $site = $this->getSiteById($site_id);
         $workflow = $site->getSolr()->disable();
         $this->processWorkflow($workflow);

--- a/src/Commands/Solr/EnableCommand.php
+++ b/src/Commands/Solr/EnableCommand.php
@@ -27,9 +27,17 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_id Site name
      *
      * @usage <site> Enables Solr add-on for <site>.
+     *
+     * @deprecated Use 'search:enable --flavor=solr' instead. This command will be removed in a future version.
      */
     public function enable($site_id)
     {
+        $this->log()->warning(
+            'The "solr:enable" command is deprecated. ' .
+            'Please use "search:enable --flavor=solr" instead. ' .
+            'This command will be removed in a future version of Terminus.'
+        );
+
         $site = $this->getSiteById($site_id);
         $workflow = $site->getSolr()->enable();
         $this->processWorkflow($workflow);

--- a/src/Models/Elasticsearch.php
+++ b/src/Models/Elasticsearch.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+class Elasticsearch extends AddOnModel
+{
+    public const PRETTY_NAME = 'Elasticsearch';
+
+    /**
+     * Disables Elasticsearch indexing
+     *
+     * @return Workflow
+     */
+    public function disable()
+    {
+        $site = $this->getSite();
+        return $site->getWorkflows()->create('disable_addon', [
+            'params' => [
+                'addon' => 'elasticsearch',
+            ],
+        ]);
+    }
+
+    /**
+     * Enables Elasticsearch indexing
+     *
+     * @return Workflow
+     */
+    public function enable()
+    {
+        $site = $this->getSite();
+        return $site->getWorkflows()->create('enable_addon', [
+            'params' => [
+                'addon' => 'elasticsearch',
+            ],
+        ]);
+    }
+}

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -87,6 +87,11 @@ class Site extends TerminusModel implements
     protected $solr;
 
     /**
+     * @var Elasticsearch
+     */
+    protected $elasticsearch;
+
+    /**
      * @var SiteUserMemberships
      */
     protected $user_memberships;
@@ -402,6 +407,20 @@ class Site extends TerminusModel implements
             $this->solr = $this->getContainer()->get($nickname);
         }
         return $this->solr;
+    }
+
+    /**
+     * @return Elasticsearch
+     */
+    public function getElasticsearch()
+    {
+        if (empty($this->elasticsearch)) {
+            $nickname = \uniqid(__FUNCTION__ . "-");
+            $this->getContainer()->add($nickname, Elasticsearch::class)
+                ->addArguments([null, ['site' => $this]]);
+            $this->elasticsearch = $this->getContainer()->get($nickname);
+        }
+        return $this->elasticsearch;
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -264,6 +264,7 @@ EOD;
         $container->add(\Pantheon\Terminus\Models\Commit::class);
         $container->add(\Pantheon\Terminus\Models\DNSRecord::class);
         $container->add(\Pantheon\Terminus\Models\Domain::class);
+        $container->add(\Pantheon\Terminus\Models\Elasticsearch::class);
         $container->add(\Pantheon\Terminus\Models\Environment::class);
         $container->add(\Pantheon\Terminus\Models\Lock::class);
         $container->add(\Pantheon\Terminus\Models\MachineToken::class);
@@ -429,6 +430,8 @@ EOD;
             'Pantheon\\Terminus\\Commands\\SSHKey\\AddCommand',
             'Pantheon\\Terminus\\Commands\\SSHKey\\ListCommand',
             'Pantheon\\Terminus\\Commands\\SSHKey\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Search\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Search\\EnableCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ConfigDumpCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ConsoleCommand',

--- a/tests/Functional/SearchCommandsTest.php
+++ b/tests/Functional/SearchCommandsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Functional;
+
+/**
+ * Class SearchCommandsTest.
+ *
+ * @package Pantheon\Terminus\Tests\Functional
+ */
+class SearchCommandsTest extends TerminusTestBase
+{
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Search\EnableCommand
+     *
+     * @group search
+     * @group long
+     */
+    public function testSearchEnableCommand()
+    {
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('search:enable %s', $this->getSiteName()));
+    }
+
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Search\DisableCommand
+     *
+     * @group search
+     * @group long
+     */
+    public function testSearchDisableCommand()
+    {
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('search:disable %s', $this->getSiteName()));
+    }
+
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Search\EnableCommand
+     *
+     * @group search
+     * @group long
+     */
+    public function testSearchEnableCommandWithSolrFlavor()
+    {
+        $this->assertTerminusCommandSucceedsInAttempts(
+            sprintf('search:enable %s --flavor=solr', $this->getSiteName())
+        );
+    }
+
+    /**
+     * @test
+     * @covers \Pantheon\Terminus\Commands\Search\DisableCommand
+     *
+     * @group search
+     * @group long
+     */
+    public function testSearchDisableCommandWithSolrFlavor()
+    {
+        $this->assertTerminusCommandSucceedsInAttempts(
+            sprintf('search:disable %s --flavor=solr', $this->getSiteName())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds Elasticsearch support for WordPress sites and introduces new unified `search:enable` and `search:disable` commands that support both Solr and Elasticsearch, while deprecating the old `solr:*` commands.

## Changes

### New Commands
- **`search:enable`** - Enable search indexing with auto-detection or explicit `--flavor` flag
- **`search:disable`** - Disable search indexing with auto-detection or explicit `--flavor` flag

### Features
- **Auto-detection**: Automatically selects the appropriate search flavor based on site framework:
  - Drupal sites → defaults to Solr
  - WordPress sites → defaults to Elasticsearch
- **`--flavor` flag**: Accepts `solr` or `elasticsearch` for explicit control
- **Framework validation**: Blocks Drupal sites from using Elasticsearch (not supported)
- **Entitlement validation**: Delegates to Pantheon API to validate Elasticsearch access for WordPress sites
- **Documentation link**: Shows configuration docs after successfully enabling Elasticsearch
- **Deprecation warnings**: Old `solr:enable` and `solr:disable` commands still work but show deprecation notices

### Implementation Details
- Created new `Elasticsearch` model extending `AddOnModel`
- Added `getElasticsearch()` accessor to `Site` model
- New `Search` command namespace with enable/disable commands
- Updated deprecated `Solr` commands with warnings
- Added functional tests for new search commands

## API Integration

Uses Pantheon workflow API:
- Enable: `enable_addon` workflow with `addon: elasticsearch`
- Disable: `disable_addon` workflow with `addon: elasticsearch`

## Testing

Added functional tests:
- `SearchCommandsTest::testSearchEnableCommand()`
- `SearchCommandsTest::testSearchDisableCommand()`
- `SearchCommandsTest::testSearchEnableCommandWithSolrFlavor()`
- `SearchCommandsTest::testSearchDisableCommandWithSolrFlavor()`

## Usage Examples

```bash
# WordPress site - auto-detects Elasticsearch
terminus search:enable my-wp-site

# Explicitly use Elasticsearch
terminus search:enable my-wp-site --flavor=elasticsearch

# Use Solr instead
terminus search:enable my-wp-site --flavor=solr

# Drupal site - auto-detects Solr
terminus search:enable my-drupal-site

# Disable search
terminus search:disable my-site
```

## Backward Compatibility

✅ Existing `solr:enable` and `solr:disable` commands continue to work
✅ Deprecation warnings guide users to new commands
✅ No breaking changes

## Files Changed

**Created:**
- `src/Models/Elasticsearch.php`
- `src/Commands/Search/EnableCommand.php`
- `src/Commands/Search/DisableCommand.php`
- `tests/Functional/SearchCommandsTest.php`

**Modified:**
- `src/Models/Site.php` (added `getElasticsearch()`)
- `src/Commands/Solr/EnableCommand.php` (added deprecation warning)
- `src/Commands/Solr/DisableCommand.php` (added deprecation warning)