### PR TITLE
Add API-driven user notice mechanism via X-Pantheon-Notices header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
   "autoload-dev": {
     "psr-4": {
       "Pantheon\\Terminus\\Tests\\Functional\\": "tests/Functional/",
+      "Pantheon\\Terminus\\Tests\\Unit\\": "tests/Unit/",
       "Pantheon\\Terminus\\FeatureTests\\": "tests/features/bootstrap/",
       "Pantheon\\Terminus\\Scripts\\": "scripts/"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/config/bootstrap.php" colors="true">
     <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">tests/Unit/</directory>
+        </testsuite>
         <testsuite name="functional">
             <directory suffix="Test.php">tests/Functional/</directory>
         </testsuite>

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -19,6 +19,8 @@ use Pantheon\Terminus\Exceptions\TerminusUnsupportedSiteException;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
 use Pantheon\Terminus\Helpers\Utility\TraceId;
 use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Style\TerminusStyle;
+use Symfony\Component\Console\Input\ArrayInput;
 use Pantheon\Terminus\Session\SessionAwareTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -76,12 +78,22 @@ class Request implements
 
     public const UNSUPPORTED_SITE_EXCEPTION_MESSAGE = 'This is not supported for this site.';
 
+    public const NOTICES_HEADER = 'X-Pantheon-Notices';
+
     protected ClientInterface $client;
 
     /**
      * @var array Names of the values to strip from debug output
      */
     protected $sensitive_data = ['machine_token', 'Authorization', 'session',];
+
+    /**
+     * Tracks which API notice messages have already been displayed
+     * to avoid showing duplicates within a single command invocation.
+     *
+     * @var array<string, true>
+     */
+    private static array $displayedNotices = [];
 
     /**
      * Download file from target URL.
@@ -456,12 +468,75 @@ class Request implements
             }
         }
 
+        $this->processApiNotices($response);
+
         return new RequestOperationResult([
             'data' => $decoded_body ?? $body,
             'headers' => $headers,
             'status_code' => $statusCode,
             'status_code_reason' => $response->getReasonPhrase(),
         ]);
+    }
+
+    /**
+     * Processes API notices from the X-Pantheon-Notices response header.
+     *
+     * The header value is a JSON array of notice objects, each with:
+     *   - "message" (string, required): The message to display.
+     *   - "level" (string, optional): One of "info", "warning", or "alert".
+     *     Defaults to "info".
+     *
+     * Each unique message is displayed at most once per command invocation.
+     *
+     * @param ResponseInterface $response The HTTP response to check for notices
+     */
+    private function processApiNotices(ResponseInterface $response): void
+    {
+        $header = $response->getHeaderLine(self::NOTICES_HEADER);
+        if (empty($header)) {
+            return;
+        }
+
+        try {
+            $notices = json_decode($header, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $this->logger->debug(
+                'Failed to parse {header} header: {error}',
+                ['header' => self::NOTICES_HEADER, 'error' => $e->getMessage()]
+            );
+            return;
+        }
+
+        if (!is_array($notices)) {
+            return;
+        }
+
+        foreach ($notices as $notice) {
+            if (!is_object($notice) || empty($notice->message)) {
+                continue;
+            }
+
+            $hash = md5($notice->message);
+            if (isset(self::$displayedNotices[$hash])) {
+                continue;
+            }
+            self::$displayedNotices[$hash] = true;
+
+            $level = $notice->level ?? 'info';
+            switch ($level) {
+                case 'warning':
+                    $this->logger->warning($notice->message);
+                    break;
+                case 'alert':
+                    $style = new TerminusStyle(new ArrayInput([]), $this->output());
+                    $style->warning($notice->message);
+                    break;
+                case 'info':
+                default:
+                    $this->logger->notice($notice->message);
+                    break;
+            }
+        }
     }
 
     /**

--- a/tests/Unit/Request/RequestApiNoticesTest.php
+++ b/tests/Unit/Request/RequestApiNoticesTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit\Request;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use League\Container\Container;
+use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\Session\Session;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Robo\Config\Config;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Tests for the X-Pantheon-Notices header processing in Request.
+ */
+class RequestApiNoticesTest extends TestCase
+{
+    private Request $request;
+    private LoggerInterface $logger;
+    private BufferedOutput $output;
+    private ClientInterface $client;
+    private \ReflectionProperty $clientProperty;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Reset the static displayed notices between tests.
+        $ref = new \ReflectionClass(Request::class);
+        $prop = $ref->getProperty('displayedNotices');
+        $prop->setValue(null, []);
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->output = new BufferedOutput();
+        $this->client = $this->createMock(ClientInterface::class);
+
+        $this->request = new Request();
+        $this->request->setLogger($this->logger);
+
+        // Inject output via the IO trait.
+        $input = new ArrayInput([]);
+        $this->request->setInput($input);
+        $this->request->setOutput($this->output);
+
+        // Set up config.
+        $config = new Config();
+        $config->set('protocol', 'https');
+        $config->set('host', 'localhost');
+        $config->set('port', '443');
+        $config->set('client_options', []);
+        $config->set('version', '4.0.0');
+        $config->set('php_version', '8.1');
+        $config->set('script', 'terminus');
+        $this->request->setConfig($config);
+
+        // Set up a mock session.
+        $session = $this->createMock(Session::class);
+        $session->method('get')->willReturn('fake-session-token');
+        $this->request->setSession($session);
+
+        // Set up container with input.
+        $container = new Container();
+        $container->add('input', $input);
+        $this->request->setContainer($container);
+
+        // Inject the mock client via reflection.
+        $this->clientProperty = new \ReflectionProperty(Request::class, 'client');
+        $this->clientProperty->setValue($this->request, $this->client);
+    }
+
+    public function testNoNoticesHeader(): void
+    {
+        $response = new Response(200, [], json_encode(['id' => '123']));
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->never())->method('notice');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testInfoLevelNotice(): void
+    {
+        $notices = [['message' => 'This is an informational notice.', 'level' => 'info']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with('This is an informational notice.');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testWarningLevelNotice(): void
+    {
+        $notices = [['message' => 'This is a warning.', 'level' => 'warning']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with('This is a warning.');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testAlertLevelNotice(): void
+    {
+        $notices = [['message' => 'Critical alert message!', 'level' => 'alert']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->request->request('https://example.com/api/test');
+
+        $output = $this->output->fetch();
+        $this->assertStringContainsString('Critical alert message!', $output);
+    }
+
+    public function testDefaultLevelIsInfo(): void
+    {
+        $notices = [['message' => 'No level specified.']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with('No level specified.');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testDuplicateNoticesDisplayedOnce(): void
+    {
+        $notices = [['message' => 'Duplicate notice.', 'level' => 'info']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        // The notice logger should be called exactly once across two requests.
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with('Duplicate notice.');
+
+        $this->request->request('https://example.com/api/test');
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testMultipleDistinctNotices(): void
+    {
+        $notices = [
+            ['message' => 'First notice.', 'level' => 'info'],
+            ['message' => 'Second notice.', 'level' => 'warning'],
+        ];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('notice')
+            ->with('First notice.');
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with('Second notice.');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testMalformedHeaderIgnored(): void
+    {
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => 'not valid json{{{'],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('debug')
+            ->with(
+                $this->stringContains('Failed to parse'),
+                $this->anything()
+            );
+        $this->logger->expects($this->never())->method('notice');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testEmptyArrayNoOutput(): void
+    {
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => '[]'],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->never())->method('notice');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testNoticeWithEmptyMessageSkipped(): void
+    {
+        $notices = [['message' => '', 'level' => 'info'], ['level' => 'warning']];
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => json_encode($notices)],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->never())->method('notice');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->request->request('https://example.com/api/test');
+    }
+
+    public function testNonArrayHeaderValueIgnored(): void
+    {
+        $response = new Response(
+            200,
+            [Request::NOTICES_HEADER => '"just a string"'],
+            json_encode(['id' => '123'])
+        );
+        $this->client->method('send')->willReturn($response);
+
+        $this->logger->expects($this->never())->method('notice');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->request->request('https://example.com/api/test');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds support for a new `X-Pantheon-Notices` response header that allows the backend API to send custom messages to Terminus users
- When present, Terminus parses the JSON array of notice objects and displays them based on severity level (`info`, `warning`, `alert`)
- Each unique message is deduplicated within a single command invocation
- Adds unit test infrastructure (test suite config, autoload namespace) and 11 unit tests

## Design

Uses HTTP response headers rather than body fields to ensure full backward compatibility — older Terminus versions simply ignore unknown headers.

### Header format

```
X-Pantheon-Notices: [{"message":"We noticed a problem...","level":"warning"}]
```

### Display levels

| Level | Output method |
|-------|--------------|
| `info` (default) | `logger->notice()` |
| `warning` | `logger->warning()` |
| `alert` | SymfonyStyle `warning()` block (visually prominent banner) |

## Test plan

- [x] Unit tests pass: `vendor/bin/phpunit --no-configuration --bootstrap vendor/autoload.php tests/Unit/` (11 tests, 11 assertions)
- [ ] Integration test with API backend returning the header