### PR TITLE
Add domain:verify command for domain ownership verification

### DIFF
--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Domain;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+/**
+ * Class VerifyCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Domain
+ */
+class VerifyCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use RequestAwareTrait;
+
+    /**
+     * Verifies ownership of a domain attached to an environment.
+     *
+     * @authorize
+     * @interact
+     *
+     * @command domain:verify
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param string $domain Domain e.g. `example.com`
+     *
+     * @usage <site>.<env> <domain_name> Verifies ownership of <domain_name> on <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function verify($site_env, $domain)
+    {
+        $env = $this->getEnv($site_env);
+        $site = $this->getSiteById($site_env);
+
+        $url = sprintf(
+            'sites/%s/environments/%s/hostnames/%s/verify-ownership',
+            $site->id,
+            $env->id,
+            rawurlencode($domain)
+        );
+
+        $response = $this->request()->request($url, [
+            'method' => 'POST',
+            'json' => new \stdClass(),
+        ]);
+
+        if ($response->isError()) {
+            throw new TerminusException(
+                'Ownership verification failed for {domain} on {site}.{env}.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+
+        $data = $response->getData();
+
+        if (is_object($data) && isset($data->verified) && $data->verified) {
+            $this->log()->notice(
+                'Ownership of {domain} on {site}.{env} has been verified.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        } else {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet. '
+                . 'Ensure your DNS TXT record is configured correctly.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+    }
+}

--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -48,7 +48,7 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
 
         $response = $this->request()->request($url, [
             'method' => 'POST',
-            'json' => new \stdClass(),
+            'json' => ['challenge_type' => 'dns-01'],
         ]);
 
         if ($response->isError()) {
@@ -72,6 +72,31 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
                     'site' => $site->getName(),
                     'env' => $env->getName(),
                 ]
+            );
+            return;
+        }
+
+        // Display the TXT record value if available in the response.
+        if (is_object($data) && isset($data->token)) {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+            $this->log()->notice(
+                'Add the following TXT record to your DNS provider:' . PHP_EOL
+                . '  Name:  _acme-challenge.{domain}' . PHP_EOL
+                . '  Value: {token}',
+                [
+                    'domain' => $domain,
+                    'token' => $data->token,
+                ]
+            );
+            $this->log()->notice(
+                'Once the TXT record is in place, re-run this command to verify.'
             );
         } else {
             $this->log()->warning(

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -366,6 +366,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\AddCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\VerifyCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CloneContentCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',

--- a/tests/Functional/DomainCommandsTest.php
+++ b/tests/Functional/DomainCommandsTest.php
@@ -40,10 +40,24 @@ class DomainCommandsTest extends TerminusTestBase
         $this->assertContains($testDomain, $domains, 'Domain list should contain added domain');
 
         // Verify domain ownership - expected to report not yet verified since no TXT record exists.
+        // The command should return TXT record details or a pending verification warning.
         $verifyOutput = $this->terminusWithStderrRedirected(
             sprintf('domain:verify %s %s', $siteEnv, $testDomain)
         );
         $this->assertNotEmpty($verifyOutput, 'domain:verify should produce output');
+        $this->assertStringContainsString(
+            'not been verified yet',
+            $verifyOutput,
+            'domain:verify should indicate the domain is not yet verified'
+        );
+        // If the API returns a TXT token, the output should include TXT record instructions.
+        if (str_contains($verifyOutput, 'TXT record')) {
+            $this->assertStringContainsString(
+                '_acme-challenge.' . $testDomain,
+                $verifyOutput,
+                'domain:verify should display the expected TXT record name'
+            );
+        }
 
         $lookUpResult = $this->terminusJsonResponse(sprintf('domain:lookup %s', $testDomain));
         $this->assertIsArray($lookUpResult);

--- a/tests/Functional/DomainCommandsTest.php
+++ b/tests/Functional/DomainCommandsTest.php
@@ -16,6 +16,7 @@ class DomainCommandsTest extends TerminusTestBase
      * @covers \Pantheon\Terminus\Commands\Domain\ListCommand
      * @covers \Pantheon\Terminus\Commands\Domain\LookupCommand
      * @covers \Pantheon\Terminus\Commands\Domain\RemoveCommand
+     * @covers \Pantheon\Terminus\Commands\Domain\VerifyCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\AddCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\RemoveCommand
      *
@@ -37,6 +38,12 @@ class DomainCommandsTest extends TerminusTestBase
         $domainList = $this->terminusJsonResponse(sprintf('domain:list %s', $siteEnv));
         $domains = array_column($domainList, 'id');
         $this->assertContains($testDomain, $domains, 'Domain list should contain added domain');
+
+        // Verify domain ownership - expected to report not yet verified since no TXT record exists.
+        $verifyOutput = $this->terminusWithStderrRedirected(
+            sprintf('domain:verify %s %s', $siteEnv, $testDomain)
+        );
+        $this->assertNotEmpty($verifyOutput, 'domain:verify should produce output');
 
         $lookUpResult = $this->terminusJsonResponse(sprintf('domain:lookup %s', $testDomain));
         $this->assertIsArray($lookUpResult);


### PR DESCRIPTION
## Summary
- Adds a new `domain:verify` command that verifies ownership of a domain attached to an environment
- Calls `POST /sites/{site-id}/environments/{env}/hostnames/{hostname}/verify-ownership`
- Reports whether verification succeeded or is still pending, guiding the user to check their DNS TXT record

## Usage
```
terminus domain:verify <site>.<env> <domain>
```

## Test plan
- [ ] Run `terminus domain:verify <site>.live <domain>` against a site with a verified domain and confirm success message
- [ ] Run against a domain with pending verification and confirm warning message with TXT record guidance
- [ ] Run against an invalid domain and confirm error handling
- [ ] Verify `terminus list domain` shows the new command
- [ ] Run `composer cs` to confirm code style passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)