### PR TITLE
[DEVX-6720] Terminus 4.2.0-rc.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.2.0-rc.1 - 2026-03-16
+## 4.2.0-rc.1 - 2026-03-18
 
 ### Added
 
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file. This projec
 - Merge terminus-repository-plugin into core (#2792)
 - Merge terminus-node-logs-plugin into core (#2791)
 - Add `search:enable` and `search:disable` commands for managing search indexing (#2783, #2784)
+- Add `domain:verify` command for domain ownership verification (#2790)
+- Add `node:builds:wait` command for STA site deployments (#2798)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.5-dev
+## 4.2.0-rc.1 - 2026-03-16
 
 ### Added
 
-- Add `search:enable` and `search:disable` commands for managing search indexing
+- Merge terminus-secrets-manager-plugin into core (#2764)
+- Merge terminus-repository-plugin into core (#2792)
+- Merge terminus-node-logs-plugin into core (#2791)
+- Add `search:enable` and `search:disable` commands for managing search indexing (#2783, #2784)
 
 ### Deprecated
 
 - `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
 
 ### Fixed
+
+- Empty body should be object, not array (#2780)
 
 ## 4.1.4 - 2026-02-02
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5-dev'
+TERMINUS_VERSION: '4.2.0-rc.1'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

- Release Terminus 4.2.0-rc.1 (pre-release / release candidate)
- Version bump in `config/constants.yml`
- Changelog updated with all changes since 4.1.4

### Changes included in this release

- Merge terminus-secrets-manager-plugin into core (#2764)
- Merge terminus-repository-plugin into core (#2792)
- Merge terminus-node-logs-plugin into core (#2791)
- Add Elasticsearch support with unified search commands (#2783, #2784)
- Empty body should be object, not array (#2780)

Jira: https://getpantheon.atlassian.net/browse/DEVX-6720