### PR TITLE
[DEVX-6721] Terminus 4.1.5 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.5-dev
+## 4.1.5 - 2026-03-16
 
 ### Added
 
-- Add `search:enable` and `search:disable` commands for managing search indexing
+- [SITE-5394] Add `search:enable` and `search:disable` commands for managing Elasticsearch search indexing (#2783, #2784)
 
 ### Deprecated
 
 - `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
 
 ### Fixed
+
+- Empty body should be object, not array (#2780)
 
 ## 4.1.4 - 2026-02-02
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5-dev'
+TERMINUS_VERSION: '4.1.5'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

Stable release of Terminus 4.1.5 with new search commands, branched from 4.x prior to the plugin merge commits (which will ship in 4.2.0).

### Changes in this release

- **[SITE-5394] Elasticsearch search commands**: New `search:enable` and `search:disable` commands for managing search indexing (#2783, #2784)
  - Coming soon. These commands are currently non-functional until platform compatibility is added
- **Deprecation**: `solr:enable` and `solr:disable` deprecated in favor of new search commands
- **Fix**: Empty body should be object, not array (#2780)

### What's excluded

The following 4.x commits are intentionally excluded from this release and will ship in 4.2.0:
- Merge terminus-secrets-manager-plugin into core (#2764)
- Merge terminus-repository-plugin into core (#2792)
- Merge terminus-node-logs-plugin into core (#2791)

### Links

- DEVX ticket: https://getpantheon.atlassian.net/browse/DEVX-6721
- CCB ticket: https://getpantheon.atlassian.net/browse/CCB-2586
- Docs PR: https://github.com/pantheon-systems/documentation/pull/9960

[SITE-5394]: https://getpantheon.atlassian.net/browse/SITE-5394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ