### PR TITLE
Fix domain:verify to display DNS challenge details when unverified

### DIFF
--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -62,9 +62,24 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
             );
         }
 
-        $data = $response->getData();
+        // Fetch the domain details to check verification status and challenge info.
+        $domainUrl = sprintf(
+            'sites/%s/environments/%s/domains/%s',
+            $site->id,
+            $env->id,
+            rawurlencode($domain)
+        );
+        $domainResponse = $this->request()->request($domainUrl, [
+            'method' => 'get',
+        ]);
+        $data = $domainResponse->getData();
 
-        if (is_object($data) && isset($data->verified) && $data->verified) {
+        // Check if already verified.
+        if (
+            is_object($data)
+            && !empty($data->ownership_status)
+            && $data->ownership_status->preprovision_result->status === 'success'
+        ) {
             $this->log()->notice(
                 'Ownership of {domain} on {site}.{env} has been verified.',
                 [
@@ -76,37 +91,37 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
             return;
         }
 
-        // Display the TXT record value if available in the response.
-        if (is_object($data) && isset($data->token)) {
-            $this->log()->warning(
-                'Ownership of {domain} on {site}.{env} has not been verified yet.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
-            );
+        // Display the DNS challenge info if available.
+        $this->log()->warning(
+            'Ownership of {domain} on {site}.{env} has not been verified yet.',
+            [
+                'domain' => $domain,
+                'site' => $site->getName(),
+                'env' => $env->getName(),
+            ]
+        );
+
+        if (
+            is_object($data)
+            && !empty($data->acme_preauthorization_challenges)
+            && !empty($data->acme_preauthorization_challenges->{'dns-01'})
+        ) {
+            $dnsChallenge = $data->acme_preauthorization_challenges->{'dns-01'};
             $this->log()->notice(
-                'Add the following TXT record to your DNS provider:' . PHP_EOL
-                . '  Name:  _acme-challenge.{domain}' . PHP_EOL
-                . '  Value: {token}',
+                'Add the following TXT record to your DNS provider:' . PHP_EOL . PHP_EOL
+                . '  Name:  {key}' . PHP_EOL
+                . '  Value: {value}' . PHP_EOL,
                 [
-                    'domain' => $domain,
-                    'token' => $data->token,
+                    'key' => $dnsChallenge->verification_key ?? '_acme-challenge.' . $domain,
+                    'value' => $dnsChallenge->verification_value,
                 ]
             );
             $this->log()->notice(
                 'Once the TXT record is in place, re-run this command to verify.'
             );
         } else {
-            $this->log()->warning(
-                'Ownership of {domain} on {site}.{env} has not been verified yet. '
-                . 'Ensure your DNS TXT record is configured correctly.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
+            $this->log()->notice(
+                'Ensure your DNS TXT record is configured correctly.'
             );
         }
     }

--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -62,36 +62,52 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
             );
         }
 
-        // Fetch the domain details to check verification status and challenge info.
+        // Poll the domain endpoint to check if verification completed.
+        // The POST triggers async verification, so we need to wait and check.
         $domainUrl = sprintf(
             'sites/%s/environments/%s/domains/%s',
             $site->id,
             $env->id,
             rawurlencode($domain)
         );
-        $domainResponse = $this->request()->request($domainUrl, [
-            'method' => 'get',
-        ]);
-        $data = $domainResponse->getData();
 
-        // Check if already verified.
-        if (
-            is_object($data)
-            && !empty($data->ownership_status)
-            && $data->ownership_status->preprovision_result->status === 'success'
-        ) {
-            $this->log()->notice(
-                'Ownership of {domain} on {site}.{env} has been verified.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
-            );
-            return;
+        $this->log()->notice('Verifying ownership of {domain}...', ['domain' => $domain]);
+
+        $data = null;
+        for ($i = 0; $i < 12; $i++) {
+            sleep(5);
+            $domainResponse = $this->request()->request($domainUrl, [
+                'method' => 'get',
+            ]);
+            $data = $domainResponse->getData();
+
+            if (
+                is_object($data)
+                && !empty($data->ownership_status)
+                && $data->ownership_status->preprovision_result->status === 'success'
+            ) {
+                $this->log()->notice(
+                    'Ownership of {domain} on {site}.{env} has been verified.',
+                    [
+                        'domain' => $domain,
+                        'site' => $site->getName(),
+                        'env' => $env->getName(),
+                    ]
+                );
+                return;
+            }
+
+            // If status is not in_progress, stop polling — it won't resolve by waiting.
+            if (
+                is_object($data)
+                && !empty($data->ownership_status)
+                && $data->ownership_status->preprovision_result->status !== 'in_progress'
+            ) {
+                break;
+            }
         }
 
-        // Display the DNS challenge info if available.
+        // Verification did not complete — display the DNS challenge info if available.
         $this->log()->warning(
             'Ownership of {domain} on {site}.{env} has not been verified yet.',
             [


### PR DESCRIPTION
## Summary

- The `domain:verify` command's POST to `verify-ownership` returns `$data = 1`, not an object with challenge details, so the existing code to display TXT record info never worked
- Added a separate GET request to the domain endpoint (`sites/{id}/environments/{env}/domains/{domain}`) to fetch the full domain object including `acme_preauthorization_challenges`
- When the domain isn't verified, the command now displays the actual DNS challenge `verification_key` (TXT record name) and `verification_value` from the API response, matching the approach used by the [terminus-domain-challenge plugin](https://github.com/terminus-plugin-project/terminus-domain-challenge)

## Test plan

- [ ] Run `terminus domain:verify <site>.<env> <unverified-domain>` and confirm TXT record name/value are displayed
- [ ] Run `terminus domain:verify <site>.<env> <verified-domain>` and confirm success message is shown
- [ ] Run existing functional tests (`DomainCommandsTest`)