### PR TITLE
feat(DEVX-6685): Add node:builds:wait command

### DIFF
--- a/src/Commands/Node/BuildsListCommand.php
+++ b/src/Commands/Node/BuildsListCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pantheon\Terminus\Commands;
+namespace Pantheon\Terminus\Commands\Node;
 
 use Pantheon\Terminus\Commands\Import\SiteCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
@@ -13,7 +13,7 @@ use Pantheon\Terminus\Build\BuildAwareTrait;
 /**
  * Fetch the list of builds for a site.
  */
-class NodeBuildsListCommand extends SiteCommand implements SiteAwareInterface, RequestAwareInterface
+class BuildsListCommand extends SiteCommand implements SiteAwareInterface, RequestAwareInterface
 {
     use BuildAwareTrait;
     use SiteAwareTrait;
@@ -84,7 +84,7 @@ class NodeBuildsListCommand extends SiteCommand implements SiteAwareInterface, R
      *
      * @return array|string|null
      */
-    private function getFromUrl(string $url)
+    protected function getFromUrl(string $url)
     {
         $protocol = $this->getConfig()->get('protocol');
         $host = $this->getConfig()->get('host');

--- a/src/Commands/Node/BuildsRebuildCommand.php
+++ b/src/Commands/Node/BuildsRebuildCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pantheon\Terminus\Commands;
+namespace Pantheon\Terminus\Commands\Node;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
@@ -10,11 +10,11 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\VcsApi\VcsClientAwareTrait;
 
 /**
- * Class NodeBuildRebuildCommand.
+ * Class BuildsRebuildCommand.
  *
- * @package Pantheon\Terminus\Commands
+ * @package Pantheon\Terminus\Commands\Node
  */
-class NodeBuildRebuildCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+class BuildsRebuildCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
 {
     use SiteAwareTrait;
     use VcsClientAwareTrait;

--- a/src/Commands/Node/BuildsWaitCommand.php
+++ b/src/Commands/Node/BuildsWaitCommand.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Node;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+/**
+ * Class BuildsWaitCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Node
+ */
+class BuildsWaitCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use RequestAwareTrait;
+
+    private const IN_PROGRESS_STATUSES = [
+        'BUILD_PENDING',
+        'BUILD_QUEUED',
+        'BUILD_WORKING',
+        'BUILD_SUCCESS',
+        'DEPLOYMENT_WORKING',
+        'DEPLOYMENT_QUEUED',
+    ];
+
+    private const FAILURE_STATUSES = [
+        'BUILD_FAILURE',
+        'BUILD_TIMEOUT',
+        'BUILD_CANCELLED',
+        'DEPLOYMENT_FAILURE',
+        'DEPLOYMENT_CANCELLED',
+    ];
+
+    private const SUCCESS_STATUS = 'DEPLOYMENT_SUCCESS';
+
+    /**
+     * Wait for a Node.js site build and deployment to complete.
+     *
+     * @authorize
+     *
+     * @command node:builds:wait
+     * @aliases nbw,node:build:wait
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @option string $commit Commit SHA to wait for (optional; waits for latest build if omitted)
+     * @option int $max Maximum number of seconds to wait for the build to complete
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     *
+     * @usage <site>.<env> Wait for the latest build on <site>'s <env> environment.
+     * @usage <site>.<env> --commit=<sha> Wait for a specific commit's build on <site>'s <env> environment.
+     */
+    public function buildsWait(
+        $site_env,
+        $options = [
+            'commit' => '',
+            'max' => 600,
+        ]
+    ) {
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSiteById($site_env);
+        $env = $this->getEnv($site_env);
+
+        if (!$site->isEvcs()) {
+            throw new TerminusException(
+                'This command only works for sites using external VCS (GitHub, GitLab, Bitbucket).'
+            );
+        }
+
+        if (!$site->isNodejs()) {
+            throw new TerminusException(
+                'This command only works for Node.js sites.'
+            );
+        }
+
+        $env_name = $env->getName();
+        $target_commit = $options['commit'] ?? '';
+        $maxWaitInSeconds = $options['max'];
+
+        if (!empty($target_commit)) {
+            if (!preg_match('/^[0-9a-f]{7,40}$/', $target_commit)) {
+                throw new TerminusException(
+                    'Commit {commit} is not a valid commit SHA (must be 7-40 hexadecimal characters).',
+                    ['commit' => $target_commit]
+                );
+            }
+            $this->log()->notice('Waiting for build with commit {commit} on {site} environment {env}.', [
+                'commit' => $target_commit,
+                'site' => $site->getName(),
+                'env' => $env_name,
+            ]);
+        } else {
+            $this->log()->notice('Waiting for latest build on {site} environment {env}.', [
+                'site' => $site->getName(),
+                'env' => $env_name,
+            ]);
+        }
+
+        $current_time = time();
+        if ($maxWaitInSeconds > 0) {
+            $end_time = $current_time + $maxWaitInSeconds;
+        } else {
+            $end_time = 0;
+        }
+
+        $retry_interval = $this->getConfig()->get('workflow_polling_delay_ms', 5000);
+        if ($retry_interval < 1000) {
+            $retry_interval = 1000;
+        }
+
+        $build = null;
+        $max_not_found_attempts = 10;
+        $not_found_attempts = 0;
+
+        // Phase 1: Find the build
+        do {
+            $current_time = time();
+
+            if ($end_time > 0 && $current_time >= $end_time) {
+                $this->log()->warning(
+                    'Waited \'{timeout}\' seconds, giving up waiting for build to be found',
+                    ['timeout' => $maxWaitInSeconds]
+                );
+                return;
+            }
+
+            if ($not_found_attempts >= $max_not_found_attempts) {
+                $this->log()->warning(
+                    'Build not found after {retries} attempts, giving up.',
+                    ['retries' => $max_not_found_attempts]
+                );
+                return;
+            }
+
+            $builds = $this->fetchBuilds($site->id, $env_name);
+
+            if (!empty($builds)) {
+                $build = $this->findMatchingBuild($builds, $target_commit);
+            }
+
+            if ($build) {
+                $this->log()->notice('Found build {id} with status {status}.', [
+                    'id' => $build->id,
+                    'status' => $build->status,
+                ]);
+                break;
+            }
+
+            $not_found_attempts++;
+            $this->log()->debug('Build not found, retrying... ({retry}/{max})', [
+                'retry' => $not_found_attempts,
+                'max' => $max_not_found_attempts,
+            ]);
+            usleep($retry_interval * 1000);
+        } while (true);
+
+        // Phase 2: Wait for the build to reach a terminal state
+        // Reset timeout for the wait phase (forgiving, like workflow:wait)
+        $current_time = time();
+        if ($maxWaitInSeconds > 0) {
+            $end_time = $current_time + $maxWaitInSeconds;
+        } else {
+            $end_time = 0;
+        }
+
+        do {
+            $current_time = time();
+
+            if ($end_time > 0 && $current_time >= $end_time) {
+                $this->log()->warning(
+                    'Waited \'{timeout}\' seconds, giving up waiting for build to finish',
+                    ['timeout' => $maxWaitInSeconds]
+                );
+                return;
+            }
+
+            // Check current status
+            if ($build->status === self::SUCCESS_STATUS) {
+                $this->log()->notice('Build {id} deployed successfully.', [
+                    'id' => $build->id,
+                ]);
+                return;
+            }
+
+            if (in_array($build->status, self::FAILURE_STATUSES)) {
+                throw new TerminusException(
+                    'Build {id} failed with status: {status}',
+                    ['id' => $build->id, 'status' => $build->status]
+                );
+            }
+
+            if (!in_array($build->status, self::IN_PROGRESS_STATUSES)) {
+                throw new TerminusException(
+                    'Build {id} has unexpected status: {status}',
+                    ['id' => $build->id, 'status' => $build->status]
+                );
+            }
+
+            $this->log()->debug('Build {id} status: {status}, waiting...', [
+                'id' => $build->id,
+                'status' => $build->status,
+            ]);
+
+            usleep($retry_interval * 1000);
+
+            // Re-fetch builds to get updated status
+            $builds = $this->fetchBuilds($site->id, $env_name);
+            $updated_build = $this->findBuildById($builds, $build->id);
+
+            if (!$updated_build) {
+                throw new TerminusException(
+                    'Build {id} disappeared during execution.',
+                    ['id' => $build->id]
+                );
+            }
+
+            $build = $updated_build;
+        } while (true);
+    }
+
+    /**
+     * Fetch builds from the API.
+     *
+     * @param string $site_id Site ID.
+     * @param string $env Environment name.
+     *
+     * @return array
+     */
+    private function fetchBuilds(string $site_id, string $env): array
+    {
+        $data = $this->getFromUrl(
+            sprintf('/api/sites/%s/environment/%s/build/list?%s', $site_id, $env, http_build_query([
+                'limit' => 10,
+            ]))
+        );
+
+        if (empty($data) || !is_array($data)) {
+            return [];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Find a build matching the target commit or the latest in-progress/recent build.
+     *
+     * @param array $builds Array of build objects from the API.
+     * @param string $target_commit Commit SHA to match (empty for latest).
+     *
+     * @return object|null
+     */
+    private function findMatchingBuild(array $builds, string $target_commit): ?object
+    {
+        if (!empty($target_commit)) {
+            foreach ($builds as $build) {
+                if (
+                    isset($build->commit) &&
+                    strpos($build->commit, $target_commit) === 0
+                ) {
+                    return $build;
+                }
+            }
+            return null;
+        }
+
+        // No commit specified: find the latest in-progress build,
+        // or fallback to the most recent build.
+        foreach ($builds as $build) {
+            if (in_array($build->status, self::IN_PROGRESS_STATUSES)) {
+                return $build;
+            }
+        }
+
+        // If no in-progress build, return the most recent one
+        return $builds[0] ?? null;
+    }
+
+    /**
+     * Find a build by ID in the builds array.
+     *
+     * @param array $builds Array of build objects.
+     * @param string $build_id Build ID to find.
+     *
+     * @return object|null
+     */
+    private function findBuildById(array $builds, string $build_id): ?object
+    {
+        foreach ($builds as $build) {
+            if ($build->id === $build_id) {
+                return $build;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get data from a given url.
+     *
+     * @param string $url Url to get data from.
+     *
+     * @return array|string|null
+     */
+    private function getFromUrl(string $url)
+    {
+        $protocol = $this->getConfig()->get('protocol');
+        $host = $this->getConfig()->get('host');
+
+        $url = sprintf('%s://%s%s', $protocol, $host, $url);
+
+        $options = [
+            'headers' => [
+                'X-Pantheon-Session' => $this->request->session()->get('session'),
+            ],
+        ];
+        $result = $this->request()->request($url, $options);
+        $status_code = $result->getStatusCode();
+
+        if ($status_code != 200) {
+            return null;
+        }
+
+        $data = $result->getData();
+        if (empty($data)) {
+            return null;
+        }
+
+        return $data;
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -261,6 +261,7 @@ EOD;
         $container->add(\Pantheon\Terminus\Models\Backup::class);
         $container->add(\Pantheon\Terminus\Models\Binding::class);
         $container->add(\Pantheon\Terminus\Models\Branch::class);
+        $container->add(\Pantheon\Terminus\Models\Build::class);
         $container->add(\Pantheon\Terminus\Models\Commit::class);
         $container->add(\Pantheon\Terminus\Models\DNSRecord::class);
         $container->add(\Pantheon\Terminus\Models\Domain::class);
@@ -300,6 +301,7 @@ EOD;
         $container->add(\Pantheon\Terminus\Collections\Backups::class);
         $container->add(\Pantheon\Terminus\Collections\Bindings::class);
         $container->add(\Pantheon\Terminus\Collections\Branches::class);
+        $container->add(\Pantheon\Terminus\Collections\Builds::class);
         $container->add(\Pantheon\Terminus\Collections\Commits::class);
         $container->add(\Pantheon\Terminus\Collections\DNSRecords::class);
         $container->add(\Pantheon\Terminus\Collections\Domains::class);
@@ -405,14 +407,15 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Multidev\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Multidev\\MergeFromDevCommand',
             'Pantheon\\Terminus\\Commands\\Multidev\\MergeToDevCommand',
-            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsBaseCommand',
-            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsBuildGetCommand',
-            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsRuntimeGetCommand',
             'Pantheon\\Terminus\\Commands\\NewRelic\\DisableCommand',
             'Pantheon\\Terminus\\Commands\\NewRelic\\EnableCommand',
             'Pantheon\\Terminus\\Commands\\NewRelic\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\NodeBuildRebuildCommand',
-            'Pantheon\\Terminus\\Commands\\NodeBuildsListCommand',
+            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsBaseCommand',
+            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsBuildGetCommand',
+            'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsRuntimeGetCommand',
+            'Pantheon\\Terminus\\Commands\\Node\\BuildsListCommand',
+            'Pantheon\\Terminus\\Commands\\Node\\BuildsRebuildCommand',
+            'Pantheon\\Terminus\\Commands\\Node\\BuildsWaitCommand',
             'Pantheon\\Terminus\\Commands\\Org\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Org\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Org\\People\\AddCommand',
@@ -423,10 +426,10 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Org\\Site\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Org\\Upstream\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Owner\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\PauseBuildCommand',
             'Pantheon\\Terminus\\Commands\\PaymentMethod\\AddCommand',
             'Pantheon\\Terminus\\Commands\\PaymentMethod\\ListCommand',
             'Pantheon\\Terminus\\Commands\\PaymentMethod\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\PauseBuildCommand',
             'Pantheon\\Terminus\\Commands\\Plan\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Plan\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Plan\\SetCommand',

--- a/tests/Functional/RepositoryCommandsTest.php
+++ b/tests/Functional/RepositoryCommandsTest.php
@@ -44,7 +44,7 @@ class RepositoryCommandsTest extends TerminusTestBase
 
     /**
      * @test
-     * @covers \Pantheon\Terminus\Commands\NodeBuildsListCommand
+     * @covers \Pantheon\Terminus\Commands\Node\BuildsListCommand
      *
      * @group repository
      * @group long


### PR DESCRIPTION
## Summary
- Adds `node:builds:wait` command that polls the build list API until a Node.js site's build and deployment reaches a terminal state (`DEPLOYMENT_SUCCESS`, `BUILD_FAILURE`, `DEPLOYMENT_FAILURE`, etc.)
- Moves existing Node.js commands (`NodeBuildsListCommand`, `NodeBuildRebuildCommand`) into `src/Commands/Node/` subdirectory for better organization
- Designed for CI/CD pipelines (e.g., GitHub Actions) that need to wait for a deployment before running e2e tests

## Usage
```bash
# Wait for the latest build
terminus node:builds:wait my-site.dev

# Wait for a specific commit's build
terminus node:builds:wait my-site.dev --commit=abc1234

# Custom timeout (default 600s / 10 min)
terminus node:builds:wait my-site.dev --max=900
```

## Behavior
| Scenario | Exit |
|---|---|
| `DEPLOYMENT_SUCCESS` | 0 (success) |
| `BUILD_FAILURE` / `DEPLOYMENT_FAILURE` / etc. | 1 (exception) |
| Timeout (`--max`) | 0 (warning logged) |
| Build not found after retries | 0 (warning logged) |

Matches `workflow:wait` behavior for consistency.

## Test plan
- [ ] Run `terminus node:builds:wait <node-site>.dev` on a Node.js site with an active build
- [ ] Run `terminus node:builds:wait <node-site>.dev --commit=<sha>` with a known commit
- [ ] Verify timeout behavior with `--max=10`
- [ ] Verify failure case with a known-failing build
- [ ] Verify `node:builds:list` and `node:builds:rebuild` still work after the file move
- [ ] Verify aliases (`nbw`, `nbl`, `nrb`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)