### PR TITLE
[DEVX-6742] Terminus 4.1.6 Release (DO NOT MERGE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.5-dev
+## 4.1.5 - 2026-03-16
 
 ### Added
 
-- Add `search:enable` and `search:disable` commands for managing search indexing
+- [SITE-5394] Add `search:enable` and `search:disable` commands for managing Elasticsearch search indexing (#2783, #2784)
 
 ### Deprecated
 
 - `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
 
 ### Fixed
+
+- Empty body should be object, not array (#2780)
 
 ## 4.1.4 - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.1.6 - 2026-03-18
+
+### Added
+
+- Add `domain:verify` command for domain ownership verification (#2790)
+
 ## 4.1.5 - 2026-03-16
 
 ### Added

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5-dev'
+TERMINUS_VERSION: '4.1.5'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5'
+TERMINUS_VERSION: '4.1.6'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Domain;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+/**
+ * Class VerifyCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Domain
+ */
+class VerifyCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use RequestAwareTrait;
+
+    /**
+     * Verifies ownership of a domain attached to an environment.
+     *
+     * @authorize
+     * @interact
+     *
+     * @command domain:verify
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param string $domain Domain e.g. `example.com`
+     *
+     * @usage <site>.<env> <domain_name> Verifies ownership of <domain_name> on <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function verify($site_env, $domain)
+    {
+        $env = $this->getEnv($site_env);
+        $site = $this->getSiteById($site_env);
+
+        $url = sprintf(
+            'sites/%s/environments/%s/hostnames/%s/verify-ownership',
+            $site->id,
+            $env->id,
+            rawurlencode($domain)
+        );
+
+        $response = $this->request()->request($url, [
+            'method' => 'POST',
+            'json' => ['challenge_type' => 'dns-01'],
+        ]);
+
+        if ($response->isError()) {
+            throw new TerminusException(
+                'Ownership verification failed for {domain} on {site}.{env}.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+
+        $data = $response->getData();
+
+        if (is_object($data) && isset($data->verified) && $data->verified) {
+            $this->log()->notice(
+                'Ownership of {domain} on {site}.{env} has been verified.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+            return;
+        }
+
+        // Display the TXT record value if available in the response.
+        if (is_object($data) && isset($data->token)) {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+            $this->log()->notice(
+                'Add the following TXT record to your DNS provider:' . PHP_EOL
+                . '  Name:  _acme-challenge.{domain}' . PHP_EOL
+                . '  Value: {token}',
+                [
+                    'domain' => $domain,
+                    'token' => $data->token,
+                ]
+            );
+            $this->log()->notice(
+                'Once the TXT record is in place, re-run this command to verify.'
+            );
+        } else {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet. '
+                . 'Ensure your DNS TXT record is configured correctly.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -366,6 +366,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\AddCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\VerifyCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CloneContentCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',

--- a/tests/Functional/DomainCommandsTest.php
+++ b/tests/Functional/DomainCommandsTest.php
@@ -16,6 +16,7 @@ class DomainCommandsTest extends TerminusTestBase
      * @covers \Pantheon\Terminus\Commands\Domain\ListCommand
      * @covers \Pantheon\Terminus\Commands\Domain\LookupCommand
      * @covers \Pantheon\Terminus\Commands\Domain\RemoveCommand
+     * @covers \Pantheon\Terminus\Commands\Domain\VerifyCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\AddCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\RemoveCommand
      *
@@ -37,6 +38,26 @@ class DomainCommandsTest extends TerminusTestBase
         $domainList = $this->terminusJsonResponse(sprintf('domain:list %s', $siteEnv));
         $domains = array_column($domainList, 'id');
         $this->assertContains($testDomain, $domains, 'Domain list should contain added domain');
+
+        // Verify domain ownership - expected to report not yet verified since no TXT record exists.
+        // The command should return TXT record details or a pending verification warning.
+        $verifyOutput = $this->terminusWithStderrRedirected(
+            sprintf('domain:verify %s %s', $siteEnv, $testDomain)
+        );
+        $this->assertNotEmpty($verifyOutput, 'domain:verify should produce output');
+        $this->assertStringContainsString(
+            'not been verified yet',
+            $verifyOutput,
+            'domain:verify should indicate the domain is not yet verified'
+        );
+        // If the API returns a TXT token, the output should include TXT record instructions.
+        if (str_contains($verifyOutput, 'TXT record')) {
+            $this->assertStringContainsString(
+                '_acme-challenge.' . $testDomain,
+                $verifyOutput,
+                'domain:verify should display the expected TXT record name'
+            );
+        }
 
         $lookUpResult = $this->terminusJsonResponse(sprintf('domain:lookup %s', $testDomain));
         $this->assertIsArray($lookUpResult);


### PR DESCRIPTION
## Summary

Release Terminus 4.1.6, a stable patch release based on 4.1.5.

### Changes since 4.1.5

- Add `domain:verify` command for domain ownership verification (#2790)

### Notes

- This release branch is based on `update_to_4.1.5` with the `domain:verify` commit cherry-picked from `4.x`.
- This PR will not be merged — it exists for coordination, approval, and CI validation purposes.

### Links

- DEVX ticket: https://getpantheon.atlassian.net/browse/DEVX-6742
- CCB ticket: https://getpantheon.atlassian.net/browse/CCB-2609
- Documentation PR: https://github.com/pantheon-systems/documentation/pull/9965