### PR TITLE
Back to 4.2.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.2.0-dev
+
 ## 4.2.0-rc.1 - 2026-03-18
 
 ### Added

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.2.0-rc.1'
+TERMINUS_VERSION: '4.2.0-dev'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

- Bump version back to `4.2.0-dev` after `4.2.0-rc.1` release
- Add new `4.2.0-dev` section to changelog