### PR TITLE
feat(DEVX-6540): add node:builds:rollback command

### DIFF
--- a/src/Commands/Node/BuildsRollbackCommand.php
+++ b/src/Commands/Node/BuildsRollbackCommand.php
@@ -2,8 +2,6 @@
 
 namespace Pantheon\Terminus\Commands\Node;
 
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Site\SiteAwareInterface;
@@ -105,38 +103,18 @@ class BuildsRollbackCommand extends TerminusCommand implements SiteAwareInterfac
             ],
         ];
 
-        try {
-            $this->request()->request($url, $options);
-        } catch (ClientException $e) {
-            $message = $this->extractErrorMessage($e);
+        $result = $this->request()->request($url, $options);
+        $statusCode = $result->getStatusCode();
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $data = $result->getData();
+            $message = 'Rollback request failed.';
+            if (is_object($data) && !empty($data->error)) {
+                $message = $data->error;
+            } elseif (is_string($data) && !empty(trim($data))) {
+                $message = trim($data);
+            }
             throw new TerminusException($message);
-        } catch (ServerException $e) {
-            $message = $this->extractErrorMessage($e);
-            throw new TerminusException($message);
         }
-    }
-
-    /**
-     * Extract an error message from a Guzzle exception response body.
-     *
-     * @param \GuzzleHttp\Exception\RequestException $e
-     *
-     * @return string
-     */
-    private function extractErrorMessage($e): string
-    {
-        $response = $e->getResponse();
-        if ($response === null) {
-            return $e->getMessage();
-        }
-
-        $body = (string) $response->getBody();
-        // Try to extract a message from the response body (plain text from http.Error)
-        $trimmed = trim($body);
-        if (!empty($trimmed)) {
-            return $trimmed;
-        }
-
-        return sprintf('Request failed with status code %d.', $response->getStatusCode());
     }
 }

--- a/src/Commands/Node/BuildsRollbackCommand.php
+++ b/src/Commands/Node/BuildsRollbackCommand.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Node;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+/**
+ * Class BuildsRollbackCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Node
+ */
+class BuildsRollbackCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use RequestAwareTrait;
+
+    /**
+     * Rolls back a deployed build on a Node.js site environment.
+     *
+     * @authorize
+     *
+     * @command node:builds:rollback
+     * @aliases nbr,node:build:rollback
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param string $build_id The build ID to roll back to
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     *
+     * @usage <site>.<env> <build-id> Roll back <site>'s <env> environment to the specified build.
+     */
+    public function rollback($site_env, $build_id)
+    {
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSiteById($site_env);
+        $env = $this->getEnv($site_env);
+
+        if (!$site->isEvcs()) {
+            throw new TerminusException(
+                'This command only works for sites using external VCS (GitHub, GitLab, Bitbucket).'
+            );
+        }
+
+        if (!$site->isNodejs()) {
+            throw new TerminusException(
+                'This command only works for Node.js sites.'
+            );
+        }
+
+        $env_name = $env->getName();
+
+        $this->log()->notice(
+            'Initiating rollback of build {build_id} on {site} environment {env}...',
+            [
+                'build_id' => $build_id,
+                'site' => $site->getName(),
+                'env' => $env_name,
+            ]
+        );
+
+        $url = sprintf(
+            '/api/sites/%s/environment/%s/build/%s/rollback',
+            $site->get('id'),
+            $env_name,
+            $build_id
+        );
+
+        $this->postToUrl($url);
+
+        $this->log()->notice(
+            'Rollback successfully initiated for {site} environment {env} (build {build_id}).',
+            [
+                'site' => $site->getName(),
+                'env' => $env_name,
+                'build_id' => $build_id,
+            ]
+        );
+    }
+
+    /**
+     * Send a POST request to a given API path.
+     *
+     * @param string $path API path (without protocol/host).
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    private function postToUrl(string $path): void
+    {
+        $protocol = $this->getConfig()->get('protocol');
+        $host = $this->getConfig()->get('host');
+
+        $url = sprintf('%s://%s%s', $protocol, $host, $path);
+
+        $options = [
+            'method' => 'POST',
+            'headers' => [
+                'X-Pantheon-Session' => $this->request->session()->get('session'),
+            ],
+        ];
+
+        try {
+            $this->request()->request($url, $options);
+        } catch (ClientException $e) {
+            $message = $this->extractErrorMessage($e);
+            throw new TerminusException($message);
+        } catch (ServerException $e) {
+            $message = $this->extractErrorMessage($e);
+            throw new TerminusException($message);
+        }
+    }
+
+    /**
+     * Extract an error message from a Guzzle exception response body.
+     *
+     * @param \GuzzleHttp\Exception\RequestException $e
+     *
+     * @return string
+     */
+    private function extractErrorMessage($e): string
+    {
+        $response = $e->getResponse();
+        if ($response === null) {
+            return $e->getMessage();
+        }
+
+        $body = (string) $response->getBody();
+        // Try to extract a message from the response body (plain text from http.Error)
+        $trimmed = trim($body);
+        if (!empty($trimmed)) {
+            return $trimmed;
+        }
+
+        return sprintf('Request failed with status code %d.', $response->getStatusCode());
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -415,6 +415,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\NodeLogs\\NodeLogsRuntimeGetCommand',
             'Pantheon\\Terminus\\Commands\\Node\\BuildsListCommand',
             'Pantheon\\Terminus\\Commands\\Node\\BuildsRebuildCommand',
+            'Pantheon\\Terminus\\Commands\\Node\\BuildsRollbackCommand',
             'Pantheon\\Terminus\\Commands\\Node\\BuildsWaitCommand',
             'Pantheon\\Terminus\\Commands\\Org\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Org\\ListCommand',

--- a/tests/Functional/RepositoryCommandsTest.php
+++ b/tests/Functional/RepositoryCommandsTest.php
@@ -19,6 +19,7 @@ class RepositoryCommandsTest extends TerminusTestBase
     {
         $this->assertCommandExists('node:builds:list');
         $this->assertCommandExists('node:builds:rebuild');
+        $this->assertCommandExists('node:builds:rollback');
         $this->assertCommandExists('vcs:connection:add');
         $this->assertCommandExists('vcs:connection:link');
         $this->assertCommandExists('vcs:connection:list');


### PR DESCRIPTION
## Summary
- Add `terminus node:builds:rollback <site>.<env> <build-id>` command
- Validates site is EVCS and Node.js before attempting rollback
- Calls `POST /api/sites/{siteId}/environment/{env}/build/{buildId}/rollback` on pantheonapi
- Handles error responses (build not deployed, unauthorized, server errors)
- Aliases: `nbr`, `node:build:rollback`

## Usage
```
terminus node:builds:rollback mysite.live f1e71646-54a3-479b-b485-b82e6967b7d2
```

## Dependencies
- Requires pantheonapi rollback endpoint (pantheon-systems/pantheonapi#396)
- Requires tenant-controller rollback endpoint (pantheon-systems/tenant-controller#25)

## Test plan
- [x] PHP syntax check passes
- [x] Command registered in functional test
- [ ] Manual test against sandbox

Jira: [DEVX-6540](https://getpantheon.atlassian.net/browse/DEVX-6540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVX-6540]: https://getpantheon.atlassian.net/browse/DEVX-6540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ