### PR TITLE
Fix remote:drush sql-dump truncation and data corruption

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -10,6 +10,7 @@ use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Helpers\Utility\TraceId;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -320,7 +321,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
             if (Process::ERR === $type) {
                 $stderr->write($buffer);
             } else {
-                $output->write($buffer);
+                $output->write($buffer, false, OutputInterface::OUTPUT_RAW);
             }
         };
     }


### PR DESCRIPTION
## Summary

- Fix `remote:drush sql-dump` silently truncating output for large databases due to Symfony Console 6.x OutputFormatter performance regression
- Fix silent data corruption where Symfony style tags (`<info>`, `<error>`, etc.) in database content were stripped from output

## Root Cause

`SSHBaseCommand::getOutputCallback()` wrote SSH output through `$output->write($buffer)` using the default `OUTPUT_NORMAL` mode, which routes every chunk through `OutputFormatter::format()`. The formatter regex-parses data looking for console-style tags, causing:

1. **Performance regression (v4):** symfony/console 6.x formatter is ~27x slower on HTML-rich text, creating backpressure that truncates large dumps (~886MB → ~848KB)
2. **Data corruption (v3 and v4):** Literal style tags in database content are silently stripped

## Fix

Use `OutputInterface::OUTPUT_RAW` to bypass the formatter entirely. This is correct for streaming raw command output — the formatter is designed for styled console messages, not piped data.

Fixes #2804

## Test plan

- [ ] Run `terminus remote:drush <site.env> -- sql-dump` on a large database and verify complete output
- [ ] Verify output containing literal `<info>` or `<error>` strings is preserved
- [ ] Verify stderr output still displays correctly
- [ ] Run existing functional/unit test suite