### PR TITLE
feat(DEVX-6818): add active column to builds list command

### DIFF
--- a/src/Commands/Node/BuildsListCommand.php
+++ b/src/Commands/Node/BuildsListCommand.php
@@ -11,7 +11,7 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Build\BuildAwareTrait;
 
 /**
- * Fetch the list of builds for a site.
+ * List builds and their deployment status for a site environment.
  */
 class BuildsListCommand extends SiteCommand implements SiteAwareInterface, RequestAwareInterface
 {
@@ -21,7 +21,12 @@ class BuildsListCommand extends SiteCommand implements SiteAwareInterface, Reque
     use StructuredListTrait;
 
     /**
-     * Print the list of builds to the log.
+     * List builds and their deployment status for a site environment.
+     *
+     * The "deployed" field indicates whether the build was successfully deployed.
+     * The "active" field indicates whether the build is the one currently serving
+     * traffic in the environment. After a rollback, the active build may differ
+     * from the most recently deployed build.
      *
      * @authorize
      * @filter-output

--- a/src/Commands/Node/BuildsListCommand.php
+++ b/src/Commands/Node/BuildsListCommand.php
@@ -35,6 +35,7 @@ class BuildsListCommand extends SiteCommand implements SiteAwareInterface, Reque
      *   branch: Branch/Tag
      *   commit: Commit
      *   deployed: Deployed
+     *   active: Active
      *   created: Created
      *   completed: Completed
      *

--- a/src/Models/Build.php
+++ b/src/Models/Build.php
@@ -28,6 +28,7 @@ class Build extends TerminusModel
             'branch' => $data->environment->branch,
             'commit' => $data->commit ?? '',
             'deployed' => !empty($data->release_id) ? 'true' : 'false',
+            'active' => !empty($data->active) ? 'true' : 'false',
             'created' => $data->created,
         ];
     }


### PR DESCRIPTION
## Summary

- Add `active` attribute to `Build.php` model's `parseAttributes()`
- Add `active: Active` to `@field-labels` in `BuildsListCommand.php`

## Test plan
- [ ] Run `terminus node:builds:list` and verify `Active` column appears
- [ ] Verify active build shows `true` in the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)