### PR TITLE
[DEVX-6826] Terminus 4.1.8 Release [NOT FOR MERGE - Ignore merge conflicts]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.1.8 - 2026-03-30
+
+### Changed
+
+- [NCX-77] Warn users when creating sites without `--org`, ahead of Q2 2026 requirement that all sites belong to an organization (#2786)
+
 ## 4.1.7 - 2026-03-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.1.5-dev
+## 4.1.5 - 2026-03-16
 
 ### Added
 
-- Add `search:enable` and `search:disable` commands for managing search indexing
+- [SITE-5394] Add `search:enable` and `search:disable` commands for managing Elasticsearch search indexing (#2783, #2784)
 
 ### Deprecated
 
 - `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
 
 ### Fixed
+
+- Empty body should be object, not array (#2780)
 
 ## 4.1.4 - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.1.6 - 2026-03-18
+
+### Added
+
+- Add `domain:verify` command for domain ownership verification (#2790)
+
 ## 4.1.5 - 2026-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 4.1.7 - 2026-03-23
+
+### Fixed
+
+- Fix `domain:verify` to display DNS challenge details when unverified and poll for verification status (#2797)
+
 ## 4.1.6 - 2026-03-18
 
 ### Added

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.7'
+TERMINUS_VERSION: '4.1.8'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.6'
+TERMINUS_VERSION: '4.1.7'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5-dev'
+TERMINUS_VERSION: '4.1.5'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.1.5'
+TERMINUS_VERSION: '4.1.6'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Domain;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+/**
+ * Class VerifyCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Domain
+ */
+class VerifyCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use RequestAwareTrait;
+
+    /**
+     * Verifies ownership of a domain attached to an environment.
+     *
+     * @authorize
+     * @interact
+     *
+     * @command domain:verify
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param string $domain Domain e.g. `example.com`
+     *
+     * @usage <site>.<env> <domain_name> Verifies ownership of <domain_name> on <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function verify($site_env, $domain)
+    {
+        $env = $this->getEnv($site_env);
+        $site = $this->getSiteById($site_env);
+
+        $url = sprintf(
+            'sites/%s/environments/%s/hostnames/%s/verify-ownership',
+            $site->id,
+            $env->id,
+            rawurlencode($domain)
+        );
+
+        $response = $this->request()->request($url, [
+            'method' => 'POST',
+            'json' => ['challenge_type' => 'dns-01'],
+        ]);
+
+        if ($response->isError()) {
+            throw new TerminusException(
+                'Ownership verification failed for {domain} on {site}.{env}.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+
+        $data = $response->getData();
+
+        if (is_object($data) && isset($data->verified) && $data->verified) {
+            $this->log()->notice(
+                'Ownership of {domain} on {site}.{env} has been verified.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+            return;
+        }
+
+        // Display the TXT record value if available in the response.
+        if (is_object($data) && isset($data->token)) {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+            $this->log()->notice(
+                'Add the following TXT record to your DNS provider:' . PHP_EOL
+                . '  Name:  _acme-challenge.{domain}' . PHP_EOL
+                . '  Value: {token}',
+                [
+                    'domain' => $domain,
+                    'token' => $data->token,
+                ]
+            );
+            $this->log()->notice(
+                'Once the TXT record is in place, re-run this command to verify.'
+            );
+        } else {
+            $this->log()->warning(
+                'Ownership of {domain} on {site}.{env} has not been verified yet. '
+                . 'Ensure your DNS TXT record is configured correctly.',
+                [
+                    'domain' => $domain,
+                    'site' => $site->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
+    }
+}

--- a/src/Commands/Domain/VerifyCommand.php
+++ b/src/Commands/Domain/VerifyCommand.php
@@ -62,51 +62,82 @@ class VerifyCommand extends TerminusCommand implements SiteAwareInterface, Reque
             );
         }
 
-        $data = $response->getData();
+        // Poll the domain endpoint to check if verification completed.
+        // The POST triggers async verification, so we need to wait and check.
+        $domainUrl = sprintf(
+            'sites/%s/environments/%s/domains/%s',
+            $site->id,
+            $env->id,
+            rawurlencode($domain)
+        );
 
-        if (is_object($data) && isset($data->verified) && $data->verified) {
-            $this->log()->notice(
-                'Ownership of {domain} on {site}.{env} has been verified.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
-            );
-            return;
+        $this->log()->notice('Verifying ownership of {domain}...', ['domain' => $domain]);
+
+        $data = null;
+        for ($i = 0; $i < 12; $i++) {
+            sleep(5);
+            $domainResponse = $this->request()->request($domainUrl, [
+                'method' => 'get',
+            ]);
+            $data = $domainResponse->getData();
+
+            if (
+                is_object($data)
+                && !empty($data->ownership_status)
+                && $data->ownership_status->preprovision_result->status === 'success'
+            ) {
+                $this->log()->notice(
+                    'Ownership of {domain} on {site}.{env} has been verified.',
+                    [
+                        'domain' => $domain,
+                        'site' => $site->getName(),
+                        'env' => $env->getName(),
+                    ]
+                );
+                return;
+            }
+
+            // If status is not in_progress, stop polling — it won't resolve by waiting.
+            if (
+                is_object($data)
+                && !empty($data->ownership_status)
+                && $data->ownership_status->preprovision_result->status !== 'in_progress'
+            ) {
+                break;
+            }
         }
 
-        // Display the TXT record value if available in the response.
-        if (is_object($data) && isset($data->token)) {
-            $this->log()->warning(
-                'Ownership of {domain} on {site}.{env} has not been verified yet.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
-            );
+        // Verification did not complete — display the DNS challenge info if available.
+        $this->log()->warning(
+            'Ownership of {domain} on {site}.{env} has not been verified yet.',
+            [
+                'domain' => $domain,
+                'site' => $site->getName(),
+                'env' => $env->getName(),
+            ]
+        );
+
+        if (
+            is_object($data)
+            && !empty($data->acme_preauthorization_challenges)
+            && !empty($data->acme_preauthorization_challenges->{'dns-01'})
+        ) {
+            $dnsChallenge = $data->acme_preauthorization_challenges->{'dns-01'};
             $this->log()->notice(
-                'Add the following TXT record to your DNS provider:' . PHP_EOL
-                . '  Name:  _acme-challenge.{domain}' . PHP_EOL
-                . '  Value: {token}',
+                'Add the following TXT record to your DNS provider:' . PHP_EOL . PHP_EOL
+                . '  Name:  {key}' . PHP_EOL
+                . '  Value: {value}' . PHP_EOL,
                 [
-                    'domain' => $domain,
-                    'token' => $data->token,
+                    'key' => $dnsChallenge->verification_key ?? '_acme-challenge.' . $domain,
+                    'value' => $dnsChallenge->verification_value,
                 ]
             );
             $this->log()->notice(
                 'Once the TXT record is in place, re-run this command to verify.'
             );
         } else {
-            $this->log()->warning(
-                'Ownership of {domain} on {site}.{env} has not been verified yet. '
-                . 'Ensure your DNS TXT record is configured correctly.',
-                [
-                    'domain' => $domain,
-                    'site' => $site->getName(),
-                    'env' => $env->getName(),
-                ]
+            $this->log()->notice(
+                'Ensure your DNS TXT record is configured correctly.'
             );
         }
     }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -28,7 +28,7 @@ class CreateCommand extends SiteCommand
      * @param string $site_name Site name
      * @param string $label Site label
      * @param string $upstream_id Upstream name or UUID
-     * @option org Organization name, label, or ID
+     * @option org Organization name, label, or ID (required starting Q2 2026)
      * @option region Specify the service region where the site should be
      *   created. See documentation for valid regions.
      *
@@ -66,12 +66,28 @@ class CreateCommand extends SiteCommand
         if (!is_null($org_id = $options['org'])) {
             $org = $user->getOrganizationMemberships()->get($org_id)->getOrganization();
             $workflow_options['organization_id'] = $org->id;
+        } else {
+            $this->log()->warning(
+                'Starting in Q2 2026, all new sites will be required to belong to an organization. '
+                . 'Use the --org option to specify an organization when creating a site.'
+            );
         }
 
         // Create the site.
         $this->log()->notice('Creating a new site...');
         $workflow = $this->sites()->create($workflow_options);
-        $this->processWorkflow($workflow);
+        try {
+            $this->processWorkflow($workflow);
+        } catch (TerminusException $e) {
+            if (is_null($options['org']) && stripos($e->getMessage(), 'organization') !== false) {
+                throw new TerminusException(
+                    'Site creation requires an organization. Use the --org option to specify one. '
+                    . 'Example: terminus site:create {site_name} {label} {upstream_id} --org=<org-name>',
+                    compact('site_name', 'label', 'upstream_id')
+                );
+            }
+            throw $e;
+        }
 
         // Deploy the upstream.
         if ($site = $this->getSiteById($workflow->get('waiting_for_task')->site_id)) {

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -366,6 +366,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\AddCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\Primary\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\VerifyCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CloneContentCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',

--- a/tests/Functional/DomainCommandsTest.php
+++ b/tests/Functional/DomainCommandsTest.php
@@ -16,6 +16,7 @@ class DomainCommandsTest extends TerminusTestBase
      * @covers \Pantheon\Terminus\Commands\Domain\ListCommand
      * @covers \Pantheon\Terminus\Commands\Domain\LookupCommand
      * @covers \Pantheon\Terminus\Commands\Domain\RemoveCommand
+     * @covers \Pantheon\Terminus\Commands\Domain\VerifyCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\AddCommand
      * @covers \Pantheon\Terminus\Commands\Domain\Primary\RemoveCommand
      *
@@ -37,6 +38,26 @@ class DomainCommandsTest extends TerminusTestBase
         $domainList = $this->terminusJsonResponse(sprintf('domain:list %s', $siteEnv));
         $domains = array_column($domainList, 'id');
         $this->assertContains($testDomain, $domains, 'Domain list should contain added domain');
+
+        // Verify domain ownership - expected to report not yet verified since no TXT record exists.
+        // The command should return TXT record details or a pending verification warning.
+        $verifyOutput = $this->terminusWithStderrRedirected(
+            sprintf('domain:verify %s %s', $siteEnv, $testDomain)
+        );
+        $this->assertNotEmpty($verifyOutput, 'domain:verify should produce output');
+        $this->assertStringContainsString(
+            'not been verified yet',
+            $verifyOutput,
+            'domain:verify should indicate the domain is not yet verified'
+        );
+        // If the API returns a TXT token, the output should include TXT record instructions.
+        if (str_contains($verifyOutput, 'TXT record')) {
+            $this->assertStringContainsString(
+                '_acme-challenge.' . $testDomain,
+                $verifyOutput,
+                'domain:verify should display the expected TXT record name'
+            );
+        }
 
         $lookUpResult = $this->terminusJsonResponse(sprintf('domain:lookup %s', $testDomain));
         $this->assertIsArray($lookUpResult);


### PR DESCRIPTION
## Summary

Release Terminus 4.1.8 — a stable patch release branched from 4.1.7.

### Changes

- [NCX-77] Warn users when creating sites without `--org`, ahead of the Q2 2026 requirement that all sites belong to an organization (#2786)

### Release Process

This PR targets `4.x` for CI purposes. It will **not be merged** — the release tag will be created on this branch after approval, and the PR will be closed.

[NCX-77]: https://getpantheon.atlassian.net/browse/NCX-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Links
- CCB: https://getpantheon.atlassian.net/browse/CCB-2684
- Jira: https://getpantheon.atlassian.net/browse/DEVX-6826