### PR TITLE
feat: skip waiting for dev env on Node.js site creation

### DIFF
--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -762,19 +762,28 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             }
         }
 
-        // Wait for the dev environment to be ready.
-        try {
-            $this->waitForDevEnvironment($site, $preferred_platform);
-        } catch (TerminusException $e) {
-            // If the dev environment fails to wake, log a warning.
-            $this->log()->warning(
-                'Error waiting for dev environment to wake: {error_message}',
-                ['error_message' => $e->getMessage()]
+        // Wait for the dev environment to be ready (COS sites only).
+        // For STA (Node.js) sites, skip waiting and suggest using `node:builds:wait`.
+        if ($preferred_platform === 'sta') {
+            $this->log()->notice(
+                'Site creation succeeded! The dev environment build is in progress.'
+                    . ' You can watch the build status using: terminus node:builds:wait {site}.dev',
+                ['site' => $site->getName()]
             );
-            $this->log()->warning(
-                'The site and repository have been created,'
-                    . ' but the dev environment may be not yet available.'
-            );
+        } else {
+            try {
+                $this->waitForDevEnvironment($site, $preferred_platform);
+            } catch (TerminusException $e) {
+                // If the dev environment fails to wake, log a warning.
+                $this->log()->warning(
+                    'Error waiting for dev environment to wake: {error_message}',
+                    ['error_message' => $e->getMessage()]
+                );
+                $this->log()->warning(
+                    'The site and repository have been created,'
+                        . ' but the dev environment may be not yet available.'
+                );
+            }
         }
 
         // Final Success Message


### PR DESCRIPTION
## Summary
- For EVCS Node.js (STA) site creation, skip the synchronous `waitForDevEnvironment` polling loop
- Instead, print a notice that the build is in progress and suggest using `terminus node:builds:wait <site>.dev` to watch it
- COS (Drupal/WordPress) sites continue to wait for the dev environment as before

## Test plan
- [ ] Create a Node.js EVCS site and verify it no longer blocks waiting for dev environment
- [ ] Verify the notice message includes the correct site name and `node:builds:wait` command
- [ ] Verify `node:builds:wait` can be used to watch the build after site creation
- [ ] Create a COS (Drupal/WordPress) EVCS site and verify it still waits for the dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)