### PR TITLE
[BUGS-11122] Remove X-Pantheon-Styx-Hostname header requirement from env:wake

### DIFF
--- a/src/Commands/Env/WakeCommand.php
+++ b/src/Commands/Env/WakeCommand.php
@@ -51,15 +51,6 @@ class WakeCommand extends TerminusCommand implements SiteAwareInterface
             ]);
             throw new TerminusException('Could not reach {target}', $wakeStatus);
         }
-        if ($env->getSite()->isNodejs()) {
-            // We do not expect a 'styx' header for Node.js sites so if we make it here, we assume success.
-            $this->log()->notice('OK >> {target} responded', $wakeStatus);
-            return;
-        }
-        if (empty($wakeStatus['styx'])) {
-            throw new TerminusException('Pantheon headers missing, which is not quite right.');
-        }
-
         $this->log()->notice('OK >> {target} responded', $wakeStatus);
     }
 }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -1095,7 +1095,6 @@ class Environment extends TerminusModel implements
                 if ($success) {
                     return [
                         'success' => true,
-                        'styx' => $response['headers']['X-Pantheon-Styx-Hostname'],
                         'response' => $response,
                         'target' => $domain->id,
                     ];


### PR DESCRIPTION
## Summary

- Removes the `X-Pantheon-Styx-Hostname` response header check from `env:wake`, which was causing false failures for sites on GCDN (Cloudflare) beta
- The GCDN Cloudflare worker strips this header from responses, so `env:wake` reported "Pantheon headers missing" even though the environment successfully woke up
- A 200 from `/pantheon_healthcheck` on a platform domain is sufficient to confirm the environment is awake — the styx header check was a legacy validation from 2014 that is no longer necessary
- Also removes the Node.js special case that bypassed the styx check, since the check no longer exists

## Test plan

- [ ] Run `terminus env:wake` against a site on GCDN beta — should succeed without the "Pantheon headers missing" error
- [ ] Run `terminus env:wake` against a site on legacy Styx/Fastly — should still succeed (200 = success)
- [ ] Run `terminus env:wake` against a sleeping environment — should wake it and report success
- [ ] Run `terminus env:wake` against an unreachable environment — should still fail with "Could not reach" error
- [ ] Run `terminus env:wake` against a Node.js site — should succeed (no longer needs special casing)