### PR TITLE
fix: update Node.js site creation notice to match actual build behavior

### DIFF
--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -766,8 +766,9 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         // For STA (Node.js) sites, skip waiting and suggest using `node:builds:wait`.
         if ($preferred_platform === 'sta') {
             $this->log()->notice(
-                'Site creation succeeded! The dev environment build is in progress.'
-                    . ' You can watch the build status using: terminus node:builds:wait {site}.dev',
+                'Site created successfully.'
+                    . ' Push a commit to the connected Git repository to trigger your first build.'
+                    . ' You can then watch the build status using: terminus node:builds:wait {site}.dev',
                 ['site' => $site->getName()]
             );
         } else {


### PR DESCRIPTION
## Summary
- Updates the notice shown after Node.js (STA) site creation via `terminus site:create`
- The previous message (from #2810) incorrectly stated "The dev environment build is in progress" — but no build starts until a commit is pushed to the connected Git repository
- New copy: "Site created successfully. Push a commit to the connected Git repository to trigger your first build. You can then watch the build status using: terminus node:builds:wait {site}.dev"
- Aligns with the dashboard UI copy update in pantheon-systems/dashboard#5227

## Test plan
- [ ] Create a Node.js EVCS site via terminus and verify the updated notice message is displayed
- [ ] Verify the `{site}` placeholder is correctly replaced with the site name

🤖 Generated with [Claude Code](https://claude.com/claude-code)