### PR TITLE
Fix 4.2.0 changelog - remove items already released in 4.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ All notable changes to this project will be documented in this file. This projec
 - Merge terminus-secrets-manager-plugin into core (#2764)
 - Merge terminus-repository-plugin into core (#2792)
 - Merge terminus-node-logs-plugin into core (#2791)
-- Add `search:enable` and `search:disable` commands for managing search indexing (#2783, #2784)
-- Add `domain:verify` command for domain ownership verification (#2790)
 - Add `node:builds:wait` command for STA site deployments (#2798)
 - Add `node:builds:rollback` command (#2803)
 - Add active column to builds list command (#2807)
@@ -19,16 +17,8 @@ All notable changes to this project will be documented in this file. This projec
 - Skip waiting for dev environment on Node.js site creation (#2810)
 - Allow node sites to use metrics command (#2806)
 
-### Deprecated
-
-- `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
-
 ### Fixed
 
-- Empty body should be object, not array (#2780)
-- Fix domain:verify to display DNS challenge details when unverified (#2797)
-- Do not use output formatter when streaming ssh output (#2814)
-- Remove X-Pantheon-Styx-Hostname header requirement from env:wake (#2815)
 - Update check in env:wake for node sites (#2816)
 - Update Node.js site creation notice to reflect actual build trigger (#2819)
 


### PR DESCRIPTION
## Problem

The 4.2.0 changelog incorrectly included items that were already released in prior 4.1.x releases:

**Already in 4.1.6:**
- search:enable/disable commands (#2783, #2784)
- domain:verify command (#2790)
- Empty body fix (#2780)
- solr deprecation

**Already in 4.1.7:**
- Fix domain:verify DNS challenge display (#2797)

**Already in 4.1.9:**
- SSH output fix (#2814)
- env:wake X-Pantheon-Styx-Hostname fix (#2815)

## Solution

Corrected the 4.2.0 changelog to only include items actually new in 4.2.0:
- Plugin integrations (secrets-manager, repository, node-logs)
- node:builds:wait and node:builds:rollback commands
- Builds list enhancements
- Node.js site creation improvements

Will also update the GitHub release notes after merging.