### PR TITLE
[BUGS-11265] Fix premature pagination stop in org:site:list

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -325,9 +325,6 @@ class Request implements
 
             $data = (array)$resp['data'];
             if (count($data) > 0) {
-                if (count($data) < $limit) {
-                    $finished = true;
-                }
                 $start = end($data)->id;
 
                 // If the last item of the results has previously been received,


### PR DESCRIPTION
## Summary

- Removes the short-page early termination logic in `pagedRequest()` (`src/Request/Request.php`) that caused `org:site:list` to return incomplete results
- MAS can return pages with fewer items than the limit when FGA results contain mixed tuple types (Roles + Relations) that get filtered by the resolver, triggering false pagination termination
- Pagination still terminates safely via empty response (`count($data) == 0`) and dedup detection (`isset($results[$start])`)

## Context

Multiple customers reported `org:site:list` returning ~300 sites instead of 500+. Two engineers independently validated this fix — one saw 664 sites returned (up from ~300), another saw 890 matching the dashboard count.

See: https://getpantheon.atlassian.net/browse/BUGS-11265

## Test plan

- [ ] Run `terminus org:site:list` against an org with sites in supporting workspaces
- [ ] Verify all sites are returned, matching the dashboard count
- [ ] Verify pagination terminates correctly for orgs of varying sizes

🤖