### PR TITLE
fix(DEVX-7129): remove Node.js guard from lock:info

### DIFF
--- a/src/Commands/Lock/InfoCommand.php
+++ b/src/Commands/Lock/InfoCommand.php
@@ -7,7 +7,6 @@ use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
-use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class InfoCommand.
@@ -36,17 +35,10 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Displays HTTP basic authentication status and configuration for <site>'s <env> environment.
      *
      * @return \Consolidation\OutputFormatters\StructuredData\PropertyList
-     *
-     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function info($site_env)
     {
         $env = $this->getEnv($site_env);
-        if ($env->getSite()->isNodejs()) {
-            throw new TerminusException(
-                'Locking is not supported for Node.js sites.'
-            );
-        }
         return $this->getPropertyList($env->getLock());
     }
 }

--- a/src/Commands/LockHandlingCommand.php
+++ b/src/Commands/LockHandlingCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Pantheon\Terminus\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandError;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\VcsApi\VcsClientAwareTrait;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class LockHandlingCommand implements
+    SiteAwareInterface,
+    LoggerAwareInterface,
+    ContainerAwareInterface,
+    RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use LoggerAwareTrait;
+    use ContainerAwareTrait;
+    use VcsClientAwareTrait;
+
+    /**
+     * @hook post-command lock:enable
+     *
+     * @option $rebuild Trigger rebuild for application after locking (only applicable to Node sites)
+     * @default $rebuild false
+     */
+    public function postEnableCommand($result, CommandData $commandData)
+    {
+        $this->handlePostLockCommand($result, $commandData);
+    }
+
+    /**
+     * @hook post-command lock:disable
+     *
+     * @option $rebuild Trigger rebuild for application after unlocking (only applicable to Node sites)
+     * @default $rebuild false
+     */
+    public function postDisableCommand($result, CommandData $commandData)
+    {
+        $this->handlePostLockCommand($result, $commandData);
+    }
+
+    private function handlePostLockCommand($result, CommandData $commandData)
+    {
+        if ($result instanceof CommandError) {
+            return;
+        }
+
+        $input = $commandData->input();
+
+        $site_env = $input->getArgument('site_env');
+
+        list($site_id, $env_name) = explode('.', $site_env);
+
+        $site = $this->getSiteById($site_id);
+        if ($site->get('framework') !== 'nodejs') {
+            return;
+        }
+
+        $output = $commandData->output();
+        $rebuild = $input->getOption('rebuild') ?? false;
+        $interactive = $input->isInteractive();
+        if (!$rebuild && $interactive) {
+            $io = new SymfonyStyle($input, $output);
+            $rebuild = $io->confirm("Do you want to rebuild the application?", false);
+        }
+
+        if (!$rebuild) {
+            return;
+        }
+
+        $this->logger->info('Rebuilding application for environment "{env}"...', ['env' => $env_name]);
+
+        $this->getVcsClient()->rebuild($site->get('id'), $env_name);
+
+        $this->logger->notice('Application rebuild triggered for environment "{env}".', ['env' => $env_name]);
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -454,6 +454,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Secret\\Site\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Secret\\Site\\LocalGenerateCommand',
             'Pantheon\\Terminus\\Commands\\Secret\\Site\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\LockHandlingCommand',
             'Pantheon\\Terminus\\Commands\\SecretsHandlingCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ConfigDumpCommand',


### PR DESCRIPTION
## Summary
- Removes the `isNodejs()` guard from `lock:info` that previously threw "Locking is not supported for Node.js sites"
- STA sites now support environment locking via Caddy `basica

🤖 Generated with [Claude Code](https://claude.com/claude-code)