### PR TITLE
Terminus 4.3.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.3.1-dev
+## 4.3.1 - 2026-06-02
+
+### Changed
+
+- Make `--org` required for `site:create` (#2845)
 
 ## 4.3.0 - 2026-05-26
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.3.1-dev'
+TERMINUS_VERSION: '4.3.1'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
Release Terminus 4.3.1

CCB: https://getpantheon.atlassian.net/browse/CCB-2878

## Changes

### Changed
- Make `--org` required for `site:create` (#2845)