### PR TITLE
add support for passing custom build path

### DIFF
--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -298,7 +298,6 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
                         'custom_uri' => $custom_uri,
                     ];
                 }
-
             } catch (\Exception $e) {
                 $this->log()->warning(
                     "Could not fetch domains for site {site}: {error}",

--- a/src/Commands/Site/BuildPathCommand.php
+++ b/src/Commands/Site/BuildPathCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Site;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Traits\BuildPathTrait;
+use Pantheon\Terminus\VcsApi\VcsClientAwareTrait;
+
+/**
+ * Manages the build path (monorepo subdirectory) for an eVCS site.
+ */
+class BuildPathCommand extends TerminusCommand implements SiteAwareInterface, RequestAwareInterface
+{
+    use SiteAwareTrait;
+    use VcsClientAwareTrait;
+    use BuildPathTrait;
+
+    /**
+     * Displays the build path for a site.
+     *
+     * The build path is the subdirectory within the repository that the site
+     * builds from (used for monorepos). An empty value means the repository root.
+     *
+     * @authorize
+     *
+     * @command site:build-path
+     * @aliases site:build-path:get
+     *
+     * @param string $site Site name or ID
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     *
+     * @usage <site> Displays the build path for <site>.
+     */
+    public function show($site)
+    {
+        $site_obj = $this->resolveEvcsSite($site);
+
+        $data = $this->getVcsClient()->getSiteDetailsById($site_obj->id);
+        $this->assertSuccess($data, 'Error fetching site details');
+
+        $details = (array) ($data['data'][0] ?? []);
+        $build_path = $details['build_path'] ?? '';
+
+        if ($build_path === '') {
+            $this->log()->notice('{site} builds from the repository root.', ['site' => $site_obj->getName()]);
+        } else {
+            $this->log()->notice(
+                '{site} builds from: {build_path}',
+                ['site' => $site_obj->getName(), 'build_path' => $build_path]
+            );
+        }
+
+        return $build_path;
+    }
+
+    /**
+     * Sets the build path (monorepo subdirectory) for a site.
+     *
+     * Omit <path> (or pass an empty string) to reset the site to build from the
+     * repository root.
+     *
+     * @authorize
+     *
+     * @command site:build-path:set
+     *
+     * @param string $site Site name or ID
+     * @param string $path Repository-relative path to build from (e.g. apps/web). Empty resets to repo root.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     *
+     * @usage <site> apps/web Sets <site> to build from the apps/web subdirectory.
+     * @usage <site> Resets <site> to build from the repository root.
+     */
+    public function set($site, $path = '')
+    {
+        $error = self::validateBuildPath($path);
+        if ($error !== null) {
+            throw new TerminusException('Invalid build path: {error}', ['error' => $error]);
+        }
+
+        $site_obj = $this->resolveEvcsSite($site);
+
+        $data = $this->getVcsClient()->updateBuildPath($site_obj->id, $path);
+        $this->assertSuccess($data, 'Error updating build path');
+
+        if ($path === '') {
+            $this->log()->notice(
+                'Build path for {site} has been reset to the repository root.',
+                ['site' => $site_obj->getName()]
+            );
+        } else {
+            $this->log()->notice(
+                'Build path for {site} has been set to {build_path}.',
+                ['site' => $site_obj->getName(), 'build_path' => $path]
+            );
+        }
+    }
+
+    /**
+     * Resolves a site argument to a Site object, ensuring it is an eVCS site.
+     *
+     * @param string $site
+     * @return \Pantheon\Terminus\Models\Site
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    protected function resolveEvcsSite($site)
+    {
+        $site_env = "{$site}.dev";
+        $this->requireSiteIsNotFrozen($site_env);
+        $site_obj = $this->getSiteById($site_env);
+        $env = $this->getEnv($site_env);
+
+        if (!$env->isEvcsSite()) {
+            throw new TerminusException('This command only works for eVCS sites.');
+        }
+
+        return $site_obj;
+    }
+
+    /**
+     * Throws if a VCS API response did not indicate success.
+     *
+     * @param array $data
+     * @param string $context
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    protected function assertSuccess(array $data, string $context): void
+    {
+        if (isset($data['error'])) {
+            throw new TerminusException('{context}: {error}', ['context' => $context, 'error' => $data['error']]);
+        }
+        if (($data['success'] ?? false) !== true) {
+            throw new TerminusException(
+                '{context}: {error}',
+                ['context' => $context, 'error' => $data['message'] ?? 'unknown error']
+            );
+        }
+    }
+}

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -942,7 +942,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
     /**
      * Validate a repo-relative build path used for monorepo deploys.
      *
-     * Mirrors the server-side validation in go-vcs-service (CheckBuildPath):
+     * Mirrors the server-side validation:
      * empty is allowed (means repo root); otherwise the path must be relative,
      * use forward slashes, contain only safe characters, and include no
      * parent-directory traversal.

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Pantheon\Terminus\Traits\GithubInstallTrait;
+use Pantheon\Terminus\Traits\BuildPathTrait;
 
 /**
  * Creates a new site, potentially with an external Git repository.
@@ -35,6 +36,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
     use WorkflowProcessingTrait;
     use VcsClientAwareTrait;
     use GithubInstallTrait;
+    use BuildPathTrait;
 
     // Wait time for GitHub app installation to succeed.
     protected const AUTH_LINK_TIMEOUT = 600;
@@ -937,45 +939,6 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
                     compact('framework')
                 );
         }
-    }
-
-    /**
-     * Validate a repo-relative build path used for monorepo deploys.
-     *
-     * Mirrors the server-side validation:
-     * empty is allowed (means repo root); otherwise the path must be relative,
-     * use forward slashes, contain only safe characters, and include no
-     * parent-directory traversal.
-     *
-     * @param string $build_path The path to validate.
-     * @return string|null Error message if invalid, or null if valid.
-     */
-    public static function validateBuildPath(string $build_path): ?string
-    {
-        if ($build_path === '') {
-            return null;
-        }
-        if (strlen($build_path) > 512) {
-            return 'build path must not exceed 512 characters';
-        }
-        if (strpos($build_path, '\\') !== false) {
-            return 'build path must use forward slashes';
-        }
-        if (strpos($build_path, '/') === 0) {
-            return 'build path must be a relative path (no leading slash)';
-        }
-        foreach (explode('/', $build_path) as $segment) {
-            if ($segment === '') {
-                return 'build path must not contain empty segments';
-            }
-            if ($segment === '.' || $segment === '..') {
-                return "build path must not contain '.' or '..' segments";
-            }
-            if (!preg_match('/^[A-Za-z0-9._-]+$/', $segment)) {
-                return sprintf('build path segment "%s" contains invalid characters', $segment);
-            }
-        }
-        return null;
     }
 
     /**

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -71,6 +71,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
      * @option repository-name Name of the repository to create in the VCS provider. Only applies if --vcs-provider is not Pantheon.
      * @option skip-clone-repo Do not clone the repository after creation. Default is false.
      * @option vcs-host Hostname of a GitHub Enterprise Server instance (e.g., ghes.example.com). Only valid with --vcs-provider=github. Must be registered via vcs:github-host:add first.
+     * @option build-path Relative path within the repository to the buildable app (e.g., apps/web). For monorepos. Only valid with an external VCS provider. Defaults to the repository root.
      *
      * @usage <site> <label> <upstream> Creates a new Pantheon-hosted site named <site>, labeled <label>, using code from <upstream>.
      * @usage <site> <label> <upstream> --org=<org> Creates site associated with <organization>, with a Pantheon-hosted git repository.
@@ -94,6 +95,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             'repository-name' => null,
             'skip-clone-repo' => false,
             'vcs-host' => null,
+            'build-path' => null,
         ]
     ) {
         $vcs_provider = strtolower($options['vcs-provider']);
@@ -136,6 +138,22 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             if ($options['repository-name']) {
                 throw new TerminusException(
                     'The --repository-name option is not supported when using Pantheon as the VCS provider.'
+                );
+            }
+            if (!empty($options['build-path'])) {
+                throw new TerminusException(
+                    'The --build-path option is not supported when using Pantheon as the VCS provider.'
+                );
+            }
+        }
+
+        // Validate the build path format (relative subdir, no traversal).
+        if (!empty($options['build-path'])) {
+            $build_path_error = self::validateBuildPath($options['build-path']);
+            if ($build_path_error !== null) {
+                throw new TerminusException(
+                    'Invalid --build-path: {error}',
+                    ['error' => $build_path_error]
                 );
             }
         }
@@ -714,6 +732,12 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             ],
         ];
 
+        // Forward the build path (monorepo subdir) to repository creation.
+        // Omit when empty so the backend treats it as the repo root.
+        if (!empty($options['build-path'])) {
+            $workflow_params['evcs']['build_path'] = $options['build-path'];
+        }
+
         // Add optional parameters
         if ($label) {
             $workflow_params['label'] = $label;
@@ -913,6 +937,45 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
                     compact('framework')
                 );
         }
+    }
+
+    /**
+     * Validate a repo-relative build path used for monorepo deploys.
+     *
+     * Mirrors the server-side validation in go-vcs-service (CheckBuildPath):
+     * empty is allowed (means repo root); otherwise the path must be relative,
+     * use forward slashes, contain only safe characters, and include no
+     * parent-directory traversal.
+     *
+     * @param string $build_path The path to validate.
+     * @return string|null Error message if invalid, or null if valid.
+     */
+    public static function validateBuildPath(string $build_path): ?string
+    {
+        if ($build_path === '') {
+            return null;
+        }
+        if (strlen($build_path) > 512) {
+            return 'build path must not exceed 512 characters';
+        }
+        if (strpos($build_path, '\\') !== false) {
+            return 'build path must use forward slashes';
+        }
+        if (strpos($build_path, '/') === 0) {
+            return 'build path must be a relative path (no leading slash)';
+        }
+        foreach (explode('/', $build_path) as $segment) {
+            if ($segment === '') {
+                return 'build path must not contain empty segments';
+            }
+            if ($segment === '.' || $segment === '..') {
+                return "build path must not contain '.' or '..' segments";
+            }
+            if (!preg_match('/^[A-Za-z0-9._-]+$/', $segment)) {
+                return sprintf('build path segment "%s" contains invalid characters', $segment);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -467,6 +467,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Self\\Plugin\\SearchCommand',
             'Pantheon\\Terminus\\Commands\\Self\\Plugin\\UninstallCommand',
             'Pantheon\\Terminus\\Commands\\Self\\Plugin\\UpdateCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\BuildPathCommand',
             'Pantheon\\Terminus\\Commands\\Site\\CreateCommand',
             'Pantheon\\Terminus\\Commands\\Site\\DeleteCommand',
             'Pantheon\\Terminus\\Commands\\Site\\InfoCommand',

--- a/src/Traits/BuildPathTrait.php
+++ b/src/Traits/BuildPathTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pantheon\Terminus\Traits;
+
+/**
+ * Shared validation for site build paths (monorepo subdirectories).
+ */
+trait BuildPathTrait
+{
+    /**
+     * Validate a repo-relative build path used for monorepo deploys.
+     *
+     * Mirrors the server-side validation in go-vcs-service (CheckBuildPath):
+     * empty is allowed (means repo root); otherwise the path must be relative,
+     * use forward slashes, contain only safe characters, and include no
+     * parent-directory traversal.
+     *
+     * @param string $build_path The path to validate.
+     * @return string|null Error message if invalid, or null if valid.
+     */
+    public static function validateBuildPath(string $build_path): ?string
+    {
+        if ($build_path === '') {
+            return null;
+        }
+        if (strlen($build_path) > 512) {
+            return 'build path must not exceed 512 characters';
+        }
+        if (strpos($build_path, '\\') !== false) {
+            return 'build path must use forward slashes';
+        }
+        if (strpos($build_path, '/') === 0) {
+            return 'build path must be a relative path (no leading slash)';
+        }
+        foreach (explode('/', $build_path) as $segment) {
+            if ($segment === '') {
+                return 'build path must not contain empty segments';
+            }
+            if ($segment === '.' || $segment === '..') {
+                return "build path must not contain '.' or '..' segments";
+            }
+            if (!preg_match('/^[A-Za-z0-9._-]+$/', $segment)) {
+                return sprintf('build path segment "%s" contains invalid characters', $segment);
+            }
+        }
+        return null;
+    }
+}

--- a/src/VcsApi/Client.php
+++ b/src/VcsApi/Client.php
@@ -151,6 +151,32 @@ class Client implements ConfigAwareInterface
     }
 
     /**
+     * Update the build path (monorepo subdirectory) for a given site.
+     *
+     * An empty build path resets the site to building from the repository root.
+     *
+     * @param string $site_id
+     * @param string $build_path
+     *
+     * @return array
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function updateBuildPath(string $site_id, string $build_path): array
+    {
+        $request_options = [
+            'method' => 'PATCH',
+            'json' => ['build_path' => $build_path],
+        ];
+
+        return $this->requestApi(
+            'site-details/' . $site_id . '/build-path',
+            $request_options,
+            "X-Pantheon-Session"
+        );
+    }
+
+    /**
      * Pushes GitHub VCS event to the VCS API.
      */
     public function githubVcs($data, string $site_id, string $event_name): array

--- a/tests/Unit/BuildPathCommandTest.php
+++ b/tests/Unit/BuildPathCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Commands\Site\BuildPathCommand;
+
+/**
+ * Tests build path validation exposed on the site:build-path command via
+ * the shared BuildPathTrait.
+ */
+class BuildPathCommandTest extends TestCase
+{
+    /**
+     * @test
+     * @group site
+     * @group short
+     * @dataProvider validBuildPathProvider
+     */
+    public function testValidateBuildPathAcceptsValidPaths(string $path)
+    {
+        $this->assertNull(BuildPathCommand::validateBuildPath($path));
+    }
+
+    public function validBuildPathProvider(): array
+    {
+        return [
+            'empty (reset to root)' => [''],
+            'single segment' => ['apps'],
+            'nested' => ['apps/web'],
+            'dots and dashes' => ['packages/site-a.v2'],
+        ];
+    }
+
+    /**
+     * @test
+     * @group site
+     * @group short
+     * @dataProvider invalidBuildPathProvider
+     */
+    public function testValidateBuildPathRejectsInvalidPaths(string $path, string $expectedFragment)
+    {
+        $error = BuildPathCommand::validateBuildPath($path);
+        $this->assertNotNull($error, sprintf('Expected "%s" to be rejected', $path));
+        $this->assertStringContainsString($expectedFragment, $error);
+    }
+
+    public function invalidBuildPathProvider(): array
+    {
+        return [
+            'absolute path' => ['/apps/web', 'relative'],
+            'parent traversal' => ['apps/../etc', "'.' or '..'"],
+            'backslash' => ['apps\\win', 'forward slashes'],
+            'empty segment' => ['apps//web', 'empty segments'],
+            'invalid char' => ['apps/we b', 'invalid characters'],
+            'too long' => [str_repeat('a', 513), '512 characters'],
+        ];
+    }
+}

--- a/tests/Unit/CreateCommandTest.php
+++ b/tests/Unit/CreateCommandTest.php
@@ -86,4 +86,59 @@ class CreateCommandTest extends TestCase
             $expectedMessage
         );
     }
+
+    /**
+     * Valid build paths (including empty = repo root) should pass validation.
+     *
+     * @test
+     * @group site
+     * @group short
+     * @dataProvider validBuildPathProvider
+     */
+    public function testValidateBuildPathAcceptsValidPaths(string $path)
+    {
+        $this->assertNull(CreateCommand::validateBuildPath($path));
+    }
+
+    public function validBuildPathProvider(): array
+    {
+        return [
+            'empty (root)' => [''],
+            'single segment' => ['apps'],
+            'nested' => ['apps/web'],
+            'deeply nested' => ['packages/sites/web'],
+            'dots in name' => ['app.v2'],
+            'underscores and dashes' => ['my_app-2'],
+        ];
+    }
+
+    /**
+     * Invalid build paths should return a descriptive error message.
+     *
+     * @test
+     * @group site
+     * @group short
+     * @dataProvider invalidBuildPathProvider
+     */
+    public function testValidateBuildPathRejectsInvalidPaths(string $path, string $expectedFragment)
+    {
+        $error = CreateCommand::validateBuildPath($path);
+        $this->assertNotNull($error, sprintf('Expected "%s" to be rejected', $path));
+        $this->assertStringContainsString($expectedFragment, $error);
+    }
+
+    public function invalidBuildPathProvider(): array
+    {
+        return [
+            'absolute path' => ['/apps/web', 'relative'],
+            'parent traversal' => ['apps/../etc', "'.' or '..'"],
+            'leading dotdot' => ['../escape', "'.' or '..'"],
+            'current dir segment' => ['./apps', "'.' or '..'"],
+            'empty segment' => ['apps//web', 'empty segments'],
+            'backslash' => ['apps\\win', 'forward slashes'],
+            'space in segment' => ['apps/we b', 'invalid characters'],
+            'colon in segment' => ['apps/we:b', 'invalid characters'],
+            'too long' => [str_repeat('a', 513), '512 characters'],
+        ];
+    }
 }


### PR DESCRIPTION
[DEVX-7148](https://getpantheon.atlassian.net/browse/DEVX-7148)

- support custom build paths for both terminus and subgraph-evcs

[DEVX-7148]: https://getpantheon.atlassian.net/browse/DEVX-7148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ