### PR TITLE
[DEVX-7165]: Provide a configuration item to insert session token into a cookie.

### DIFF
--- a/src/Commands/SecretsHandlingCommand.php
+++ b/src/Commands/SecretsHandlingCommand.php
@@ -25,12 +25,12 @@ class SecretsHandlingCommand implements
     use ContainerAwareTrait;
     use VcsClientAwareTrait;
 
-  /**
-   * @hook post-command secret:site:set
-   *
-   * @option $rebuild Trigger rebuild for application after setting secret (only applicable to Node sites)
-   * @default $rebuild false
-   */
+    /**
+     * @hook post-command secret:site:set
+     *
+     * @option $rebuild Trigger rebuild for application after setting secret (only applicable to Node sites)
+     * @default $rebuild false
+     */
     public function postCommand($result, CommandData $commandData)
     {
         if ($result instanceof CommandError) {

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -360,6 +360,8 @@ class Request implements
      */
     public function request($path, array $options = []): RequestOperationResult
     {
+        $config = $this->getConfig();
+
         // Set headers.
         $parts = explode('/', $path);
         $part = array_pop($parts);
@@ -389,6 +391,18 @@ class Request implements
             unset($options['form_params']);
             $headers['Content-Type'] = 'application/json';
             $headers['Content-Length'] = strlen($body);
+        }
+
+        $auth_cookie_key = $config->get('auth_cookie_key');
+        if ($auth_cookie_key) {
+            $this->sensitive_data[] = 'Cookie';
+            $headers = [
+                'Cookie' => "$auth_cookie_key={$this->session()->get('session')}",
+            ];
+            if (isset($options['headers'])) {
+                $headers = array_merge($headers, $options['headers']);
+            }
+            $options['headers'] = $headers;
         }
 
         $method = isset($options['method']) ? strtoupper(

--- a/src/Traits/GithubInstallTrait.php
+++ b/src/Traits/GithubInstallTrait.php
@@ -93,8 +93,8 @@ PHP;
                 ->get(LocalMachineHelper::class)
                 ->openUrl($url_to_open);
         } catch (\Exception $e) {
-             $this->log()->warning("Could not automatically open browser: " . $e->getMessage());
-             $this->log()->warning("Please open the URL manually: " . $url_to_open);
+            $this->log()->warning("Could not automatically open browser: " . $e->getMessage());
+            $this->log()->warning("Please open the URL manually: " . $url_to_open);
         }
 
         $minutes = (int) ($timeout / 60);


### PR DESCRIPTION
Allow auth token to be inserted into a cookie if so directed via a configuration option.

Unrelated style updates in [src/Commands/SecretsHandlingCommand.php](https://github.com/pantheon-systems/terminus/compare/auth-extension-2?expand=1#diff-1fd5c86ea215345abdc19979f4e2f305593a7890ad794903dd1d60c496dc899f) and [src/Traits/GithubInstallTrait.php](https://github.com/pantheon-systems/terminus/compare/auth-extension-2?expand=1#diff-40d1bdd3964df11ce345e0b4e2240d4146172b462e61e5a206bc49eadb1c9114).