### PR TITLE
feat(DEVX-7163): GitLab support for vcs:connection:add and site:create

### DIFF
--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -936,7 +936,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
      */
     protected function handleNewInstallation(
         string $vcs_provider,
-        string $auth_url,
+        ?string $auth_url,
         string $flag_file,
         array $options,
         $pantheon_org = null

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -972,7 +972,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         if (empty($token)) {
             $this->log()->notice(
                 'A GitLab Group Access Token (Premium/self-hosted) or Personal Access Token is required.'
-                    . ' The token must have the "api" scope.'
+                    . ' The token must have "api" and "write_repository" scopes.'
             );
 
             $helper = new QuestionHelper();

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -94,14 +94,15 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             'repository-name' => null,
             'skip-clone-repo' => false,
             'vcs-host' => null,
+            'vcs-token' => null,
         ]
     ) {
         $vcs_provider = strtolower($options['vcs-provider']);
         $org_id = $options['org'];
 
-        if (!empty($options['vcs-host']) && $vcs_provider !== 'github') {
+        if (!empty($options['vcs-host']) && !in_array($vcs_provider, ['github', 'gitlab'])) {
             throw new TerminusException(
-                'The --vcs-host option is only valid with --vcs-provider=github.'
+                'The --vcs-host option is only valid with --vcs-provider=github or --vcs-provider=gitlab.'
             );
         }
 
@@ -623,7 +624,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
 
         if ($installation_id === 'new') {
             $existing_installation = false;
-            $success = $this->handleNewInstallation($vcs_provider, $auth_url, $flag_file, $options);
+            $success = $this->handleNewInstallation($vcs_provider, $auth_url, $flag_file, $options, $pantheon_org);
             if (!$success) {
                 throw new TerminusException(
                     'Error authorizing with VCS service:'
@@ -937,28 +938,29 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         string $vcs_provider,
         string $auth_url,
         string $flag_file,
-        array $options
+        array $options,
+        $pantheon_org = null
     ): bool {
         $this->log()->warning(
             "Important: Connecting this application grants all members of this"
                 . " Pantheon Workspace the ability to list and create repositories"
-                . " in the attached GitHub Organization, regardless of their"
-                . " individual GitHub permissions."
+                . " in the attached VCS Organization, regardless of their"
+                . " individual VCS permissions."
         );
         switch ($vcs_provider) {
             case 'github':
                 return $this->handleGithubNewInstallation($auth_url, $flag_file, self::AUTH_LINK_TIMEOUT);
 
             case 'gitlab':
-                return $this->handleGitLabNewInstallation($options);
+                return $this->handleGitLabNewInstallation($options, $pantheon_org);
         }
         return false;
     }
 
     /**
-     * Handle GitLab new installation.
+     * Handle GitLab new installation during site creation.
      */
-    protected function handleGitLabNewInstallation(string $site_uuid, array $options): bool
+    protected function handleGitLabNewInstallation(array $options, $pantheon_org = null): bool
     {
         $token = $options['vcs-token'] ?? null;
         if (empty($token) && !$this->input()->isInteractive()) {
@@ -968,8 +970,10 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             );
         }
         if (empty($token)) {
-            // @TODO Write correct instructions.
-            $this->log()->notice('Get a GitLab access token. More details at https://docs.pantheon.io');
+            $this->log()->notice(
+                'A GitLab Group Access Token (Premium/self-hosted) or Personal Access Token is required.'
+                    . ' The token must have the "api" scope.'
+            );
 
             $helper = new QuestionHelper();
             $question = new Question('Enter your GitLab token: ');
@@ -984,40 +988,35 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             $token = $helper->ask($this->input(), $this->output(), $question);
         }
 
-        $question = new Question("Please enter the GitLab group name to create the repositories\n");
+        $helper = $helper ?? new QuestionHelper();
+        $question = new Question('Enter the GitLab group name/path: ');
         $question->setValidator(function ($answer) {
-            if ($answer == null || '' == trim($answer)) {
+            if (empty(trim($answer ?? ''))) {
                 throw new TerminusException('Group name cannot be empty');
             }
-            return $answer;
+            return trim($answer);
         });
         $question->setMaxAttempts(3);
         $group_name = $helper->ask($this->input(), $this->output(), $question);
-        if (!$group_name) {
-            // Throw error because token cannot be empty.
-            throw new TerminusException('Group name cannot be empty');
-        }
-        $session = $this->session();
-        $user = $session->getUser();
+
+        $user = $this->session()->getUser();
 
         $post_data = [
             'token' => $token,
             'vendor' => 2,
             'installation_type' => 'cms-site',
             'platform_user' => $user->id,
-            // TODO: Backend should be updated to not need site_uuid here.
-            'site_uuid' => '',
+            'org_uuid' => $pantheon_org ? $pantheon_org->id : '',
             'vcs_organization' => $group_name,
-            // TODO: Cleanup in go-vcs-service to not need it.
-            'pantheon_session' => 'UNUSED',
         ];
-        $data = $this->getVcsClient()->installWithToken($post_data);
-        if (!$data['success']) {
-            throw new TerminusException(
-                "An error happened while authorizing: {error_message}",
-                ['error_message' => $data['data']]
-            );
+
+        $hostname = $options['vcs-host'] ?? null;
+        if (!empty($hostname)) {
+            $post_data['hostname'] = $hostname;
         }
+
+        $this->log()->notice('Registering GitLab connection...');
+        $this->getVcsClient()->installWithToken($post_data);
 
         return true;
     }

--- a/src/Commands/Vcs/Connection/AddCommand.php
+++ b/src/Commands/Vcs/Connection/AddCommand.php
@@ -8,6 +8,8 @@ use Pantheon\Terminus\VcsApi\VcsClientAwareTrait;
 use Pantheon\Terminus\Request\RequestAwareInterface;
 use Symfony\Component\Process\Process;
 use Pantheon\Terminus\Traits\GithubInstallTrait;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * Class AddCommand.
@@ -32,7 +34,7 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
     }
 
     /**
-     * Registers a GitHub App installation with the VCS API.
+     * Registers a VCS installation with the VCS API.
      *
      * @authorize
      *
@@ -40,25 +42,24 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
      * @aliases vcs-connection-add
      *
      * @param string $organization Organization name, label, or ID.
-     * @option vcs-provider VCS provider for the site repository (e.g., github, pantheon). Default (and only) is github.
-     * @option vcs-host Hostname of a GitHub Enterprise Server instance (e.g., ghes.example.com). Must be registered via vcs:github-host:add first.
+     * @option vcs-provider VCS provider (github or gitlab). Default is github.
+     * @option vcs-host Hostname of a self-hosted instance (e.g., ghes.example.com or gitlab.example.com).
+     * @option vcs-token Personal access token for the VCS provider. Only applies to gitlab.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
-     * @usage <organization> Registers a GitHub App installation with the VCS API.
+     * @usage <organization> Registers a VCS installation with the VCS API.
+     * @usage <organization> --vcs-provider=gitlab Registers a GitLab installation.
+     * @usage <organization> --vcs-provider=gitlab --vcs-host=gitlab.example.com Registers a self-hosted GitLab installation.
      */
     public function connectionAdd(string $organization, array $options = [
         'vcs-provider' => 'github',
         'vcs-host' => null,
+        'vcs-token' => null,
     ])
     {
         $vcsProvider = $options['vcs-provider'] ?? 'github';
-        if ($vcsProvider !== 'github') {
-            throw new TerminusException(
-                'Unsupported VCS provider: {provider}. Only "github" is supported.',
-                ['provider' => $vcsProvider]
-            );
-        }
+
         $organization = $this->session()->getUser()->getOrganizationMemberships()->get(
             $organization
         )->getOrganization();
@@ -68,7 +69,19 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
                 . " will be able to list and create repositories in the selected VCS organization."
         );
 
-        $this->connectGithub($organization, $options);
+        switch ($vcsProvider) {
+            case 'github':
+                $this->connectGithub($organization, $options);
+                break;
+            case 'gitlab':
+                $this->connectGitlab($organization, $options);
+                break;
+            default:
+                throw new TerminusException(
+                    'Unsupported VCS provider: {provider}. Supported providers are: github, gitlab.',
+                    ['provider' => $vcsProvider]
+                );
+        }
     }
 
     public function connectGithub($organization, array $options = [])
@@ -104,5 +117,68 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
             throw new TerminusException('GitHub App installation was not completed within the timeout period.');
         }
         $this->log()->notice('GitHub App installation completed successfully.');
+    }
+
+    public function connectGitlab($organization, array $options = [])
+    {
+        $token = $options['vcs-token'] ?? null;
+        $hostname = $options['vcs-host'] ?? null;
+
+        if (empty($token) && !$this->input()->isInteractive()) {
+            throw new TerminusException(
+                'GitLab installation requires a token.'
+                    . ' Please provide --vcs-token or run interactively.'
+            );
+        }
+
+        if (empty($token)) {
+            $this->log()->notice(
+                'A GitLab Group Access Token (Premium/self-hosted) or Personal Access Token is required.'
+                    . ' The token must have the "api" scope.'
+            );
+
+            $helper = new QuestionHelper();
+            $question = new Question('Enter your GitLab token: ');
+            $question->setValidator(function ($answer) {
+                if (empty(trim($answer ?? ''))) {
+                    throw new \RuntimeException('GitLab token cannot be empty.');
+                }
+                return trim($answer);
+            });
+            $question->setMaxAttempts(3);
+            $question->setHidden(true);
+            $token = $helper->ask($this->input(), $this->output(), $question);
+        }
+
+        $helper = $helper ?? new QuestionHelper();
+        $question = new Question('Enter the GitLab group name/path: ');
+        $question->setValidator(function ($answer) {
+            if (empty(trim($answer ?? ''))) {
+                throw new \RuntimeException('Group name cannot be empty.');
+            }
+            return trim($answer);
+        });
+        $question->setMaxAttempts(3);
+        $groupName = $helper->ask($this->input(), $this->output(), $question);
+
+        $user = $this->session()->getUser();
+
+        $post_data = [
+            'token' => $token,
+            'vendor' => 2,
+            'installation_type' => 'cms-site',
+            'platform_user' => $user->id,
+            'org_uuid' => $organization->id,
+            'vcs_organization' => $groupName,
+        ];
+
+        if (!empty($hostname)) {
+            $post_data['hostname'] = $hostname;
+        }
+
+        $this->log()->notice('Registering GitLab connection...');
+        $data = $this->getVcsClient()->installWithToken($post_data);
+
+        $this->log()->notice('GitLab installation completed successfully.');
     }
 }

--- a/src/Commands/Vcs/Connection/AddCommand.php
+++ b/src/Commands/Vcs/Connection/AddCommand.php
@@ -134,7 +134,7 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
         if (empty($token)) {
             $this->log()->notice(
                 'A GitLab Group Access Token (Premium/self-hosted) or Personal Access Token is required.'
-                    . ' The token must have the "api" scope.'
+                    . ' The token must have "api" and "write_repository" scopes.'
             );
 
             $helper = new QuestionHelper();

--- a/src/Commands/Vcs/Connection/AddCommand.php
+++ b/src/Commands/Vcs/Connection/AddCommand.php
@@ -44,7 +44,7 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
      * @param string $organization Organization name, label, or ID.
      * @option vcs-provider VCS provider (github or gitlab). Default is github.
      * @option vcs-host Hostname of a self-hosted instance (e.g., ghes.example.com or gitlab.example.com).
-     * @option vcs-token Personal access token for the VCS provider. Only applies to gitlab.
+     * @option vcs-token Access token for the VCS provider. Only applies to GitLab.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *


### PR DESCRIPTION
## Summary

- Add `--vcs-provider=gitlab` support to `vcs:connection:add` — prompts for token (hidden) and group name, calls `installWithToken` with `org_uuid` and optional `hostname`
- Fix `handleGitLabNewInstallation` in `site:create` — method signature was wrong (`string $site_uuid` param) and would crash at runtime
- Update `installWithToken` payload to use `org_uuid` instead of `site_uuid`, add optional `hostname` for self-hosted GitLab
- Allow `--vcs-host` for both `github` and `gitlab` providers

## Test plan

- [x] `terminus vcs:connection:add <org> --vcs-provider=gitlab` — prompts for token + group, registers installation
- [x] `terminus vcs:connection:add <org> --vcs-provider=gitlab --vcs-token=TOKEN --vcs-host=gitlab.example.com` — non-interactive self-hosted
- [x] `terminus vcs:connection:add <org>` — existing GitHub flow still works
- [x] `terminus site:create ... --vcs-provider=gitlab --vcs-token=TOKEN` — no longer crashes
- [x] `terminus vcs:connection:list <org>` — GitLab installation appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)