### PR TITLE
ci: parallelize functional tests to reduce runtime

### DIFF
--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -59,7 +59,6 @@ jobs:
       matrix:
         operating-system: [ 'macos-latest' ]
         php-versions: [ '8.2', '8.5' ]
-      max-parallel: 1
     env:
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
       TERMINUS_SITE: ${{ vars.TERMINUS_SITE }}


### PR DESCRIPTION
## Summary
Removes `max-parallel: 1` constraint from functional test matrix to allow PHP 8.2 and 8.5 jobs to run concurrently.

## Impact
- **Before:** Tests run serially (~26-60 minutes total)
- **After:** Tests run in parallel (~13-30 minutes total)
- **Savings:** ~50% reduction in CI time

## Why This Is Safe Now
PR #2849 added age-based orphan cleanup with a 24-hour window, which prevents concurrent CI runs from deleting each other's test multidevs. Each matrix job gets a unique `GITHUB_RUN_ID`, so multidevs created by different jobs won't be cleaned up by each other.

## Testing
- Both matrix jobs (PHP 8.2 and 8.5) will run simultaneously
- Each creates its own `test-{random}` multidev
- Orphan cleanup only deletes envs older than 24 hours
- No collision risk

## Related
- #2849 - CI: don't delete multidevs less than 1 day old (enables this change)