### PR TITLE
[DEVX-7188] [DEVX-7324] Fetch a modern jwt auth session token via direct email/password login.

### DIFF
--- a/sample-python-tool/auth-cli/auth.py
+++ b/sample-python-tool/auth-cli/auth.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Pantheon Dashboard authentication CLI.
+
+Tries multiple Auth0 authentication strategies to obtain Hermes session cookies:
+  1. Cross-origin auth (/co/authenticate + login_ticket)
+  2. New Universal Login form submission (/u/login)
+
+Prints the values of X-Pantheon-Access-Token and X-Pantheon-Session.
+"""
+
+import getpass
+import re
+import sys
+from urllib.parse import urlparse, parse_qs, urljoin, urlencode
+
+import requests
+from bs4 import BeautifulSoup
+
+ENVIRONMENTS = {
+    "production": {
+        "auth0_domain": "pantheon.auth0.com",
+        "hermes_url": "https://dashboard.pantheon.io",
+    },
+    "sandbox": {
+        "auth0_domain": "pantheon-prodmirror.us.auth0.com",
+        "hermes_url": "https://hermes.sandbox-fast.sbx04.pantheon.io",
+    },
+}
+
+AUTH0_CONNECTION = "Pantheon"
+TARGET_COOKIES = ["X-Pantheon-Access-Token", "X-Pantheon-Session"]
+MAX_HOPS = 20
+
+
+def die(msg):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def collect_target_cookies(session):
+    found = {}
+    for cookie in session.cookies:
+        if cookie.name in TARGET_COOKIES:
+            found[cookie.name] = cookie.value
+    return found
+
+
+def get_state(url):
+    return parse_qs(urlparse(url).query).get("state", [None])[0]
+
+
+def follow_full_chain(session, resp):
+    """Follow redirects and auto-submit HTML forms until settled or cookies found."""
+    for _ in range(MAX_HOPS):
+        if len(collect_target_cookies(session)) == len(TARGET_COOKIES):
+            return resp
+
+        if resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location", "")
+            if not location:
+                return resp
+            next_url = urljoin(resp.url, location)
+            p = urlparse(next_url)
+            print(f"  → {resp.status_code} to {p.netloc}{p.path}")
+            resp = session.get(next_url, allow_redirects=False, timeout=30)
+            continue
+
+        if resp.status_code == 200 and "text/html" in resp.headers.get("Content-Type", ""):
+            soup = BeautifulSoup(resp.text, "html.parser")
+            form = soup.find("form")
+            if form and form.get("action"):
+                action = form["action"]
+                if not action.startswith("http"):
+                    action = urljoin(resp.url, action)
+                fields = {}
+                for inp in form.find_all("input"):
+                    name = inp.get("name")
+                    if name:
+                        fields[name] = inp.get("value", "")
+                p = urlparse(action)
+                print(f"  → form POST to {p.netloc}{p.path}")
+                resp = session.post(action, data=fields, allow_redirects=False, timeout=30)
+                continue
+            return resp
+
+        return resp
+    return resp
+
+
+def get_authorize_url(session, hermes_url):
+    """Follow Hermes login redirect to capture the Auth0 /authorize URL."""
+    resp = session.get(
+        f"{hermes_url}/auth/providers/any/login",
+        params={"destination": "/workspace"},
+        allow_redirects=False,
+        timeout=30,
+    )
+
+    for _ in range(10):
+        if resp.status_code not in (301, 302, 303, 307, 308):
+            break
+        location = resp.headers.get("Location", "")
+        next_url = urljoin(resp.url, location)
+        if "/authorize" in urlparse(next_url).path:
+            return next_url
+        p = urlparse(next_url)
+        print(f"  → {resp.status_code} to {p.netloc}{p.path}")
+        resp = session.get(next_url, allow_redirects=False, timeout=30)
+
+    return None
+
+
+def try_cross_origin_auth(session, auth0_base, hermes_url, client_id, email, password):
+    """Strategy 1: Auth0 cross-origin authentication."""
+    print("\n[2a] Trying /co/authenticate...")
+    co_resp = session.post(
+        f"{auth0_base}/co/authenticate",
+        json={
+            "client_id": client_id,
+            "credential_type": "http://auth0.com/oauth/grant-type/password-realm",
+            "username": email,
+            "password": password,
+            "realm": AUTH0_CONNECTION,
+        },
+        headers={
+            "Origin": hermes_url,
+        },
+        timeout=30,
+    )
+
+    if co_resp.status_code != 200:
+        try:
+            msg = co_resp.json().get("error_description", co_resp.json().get("error", co_resp.text[:200]))
+        except Exception:
+            msg = co_resp.text[:200]
+        print(f"  /co/authenticate failed ({co_resp.status_code}): {msg}")
+        return None
+
+    data = co_resp.json()
+    login_ticket = data.get("login_ticket")
+    if not login_ticket:
+        print(f"  No login_ticket in response: {data}")
+        return None
+
+    print(f"  Got login_ticket: {login_ticket[:20]}...")
+    return login_ticket
+
+
+def try_new_ul_login(session, auth0_base, login_page_resp, email, password):
+    """Strategy 2: Auth0 New Universal Login form submission."""
+    state = get_state(login_page_resp.url)
+    page_path = urlparse(login_page_resp.url).path
+
+    if "/u/login/identifier" in page_path:
+        print("\n[2b] Submitting email to /u/login/identifier...")
+        # Post with minimal fields only
+        id_resp = session.post(
+            f"{auth0_base}/u/login/identifier",
+            data={"state": state, "username": email, "action": "default"},
+            headers={"Origin": auth0_base, "Referer": login_page_resp.url},
+            allow_redirects=False,
+            timeout=30,
+        )
+        print(f"  Response: HTTP {id_resp.status_code}")
+
+        if id_resp.status_code not in (302, 303):
+            print(f"  Identifier step returned HTTP {id_resp.status_code}")
+            return None
+
+        # Follow to password page
+        pw_resp = id_resp
+        for _ in range(5):
+            if pw_resp.status_code not in (301, 302, 303, 307, 308):
+                break
+            loc = pw_resp.headers.get("Location", "")
+            next_url = urljoin(pw_resp.url, loc)
+            p = urlparse(next_url)
+            print(f"  → {pw_resp.status_code} to {p.netloc}{p.path}")
+            pw_resp = session.get(next_url, allow_redirects=False, timeout=30)
+
+        pw_state = get_state(pw_resp.url) or state
+        pw_path = urlparse(pw_resp.url).path
+        print(f"  Password page: {pw_path}")
+
+        if "/u/login/identifier" in pw_path:
+            print("  Redirected back to identifier — email not recognized?")
+            return None
+
+        print("  Submitting password to /u/login...")
+        login_resp = session.post(
+            f"{auth0_base}/u/login",
+            data={"state": pw_state, "username": email, "password": password, "action": "default"},
+            headers={"Origin": auth0_base, "Referer": pw_resp.url},
+            allow_redirects=False,
+            timeout=30,
+        )
+    else:
+        print("\n[2b] Submitting credentials to /u/login...")
+        login_resp = session.post(
+            f"{auth0_base}/u/login",
+            data={"state": state, "username": email, "password": password, "action": "default"},
+            headers={"Origin": auth0_base, "Referer": login_page_resp.url},
+            allow_redirects=False,
+            timeout=30,
+        )
+
+    print(f"  Response: HTTP {login_resp.status_code}")
+    return login_resp
+
+
+def main():
+    email = input("Email: ")
+    password = getpass.getpass("Password: ")
+
+    print("\nEnvironment:")
+    print("  1) Production (dashboard.pantheon.io)")
+    print("  2) Sandbox    (sandbox-fast.sbx04)")
+    choice = input("Choice [1]: ").strip() or "1"
+    env_name = "sandbox" if choice == "2" else "production"
+    env = ENVIRONMENTS[env_name]
+    auth0_base = f"https://{env['auth0_domain']}"
+
+    print(f"\nAuthenticating against {env_name}...")
+
+    session = requests.Session()
+    session.headers["User-Agent"] = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+
+    # Step 1: Get authorize URL from Hermes
+    print("\n[1] Getting Auth0 /authorize URL from Hermes...")
+    authorize_url = get_authorize_url(session, env["hermes_url"])
+    if not authorize_url:
+        die("Could not find Auth0 /authorize redirect")
+
+    auth_params = parse_qs(urlparse(authorize_url).query)
+    client_id = auth_params.get("client_id", [None])[0]
+    state = auth_params.get("state", [None])[0]
+    print(f"  client_id={client_id[:8]}... state={state[:12]}...")
+
+    # Strategy 1: Try cross-origin auth (cleanest for CLI)
+    login_ticket = try_cross_origin_auth(session, auth0_base, env["hermes_url"], client_id, email, password)
+
+    if login_ticket:
+        # Use login_ticket with /authorize to complete the flow
+        print("\n[3] Using login_ticket with /authorize...")
+        ticket_url = authorize_url + f"&login_ticket={login_ticket}&realm={AUTH0_CONNECTION}"
+        resp = session.get(ticket_url, allow_redirects=False, timeout=30)
+        final_resp = follow_full_chain(session, resp)
+    else:
+        # Strategy 2: Fall back to New Universal Login form submission
+        print("\n  Falling back to Universal Login form submission...")
+
+        # Follow authorize URL to login page
+        print("  Following /authorize to login page...")
+        auth_resp = session.get(authorize_url, allow_redirects=False, timeout=30)
+        login_page = auth_resp
+        for _ in range(5):
+            if login_page.status_code not in (301, 302, 303, 307, 308):
+                break
+            loc = login_page.headers.get("Location", "")
+            next_url = urljoin(login_page.url, loc)
+            p = urlparse(next_url)
+            print(f"  → {login_page.status_code} to {p.netloc}{p.path}")
+            login_page = session.get(next_url, allow_redirects=False, timeout=30)
+
+        print(f"  Landed on: {urlparse(login_page.url).path}")
+
+        login_resp = try_new_ul_login(session, auth0_base, login_page, email, password)
+        if login_resp is None:
+            die("All login strategies failed")
+
+        print("\n[3] Following callback chain → Hermes...")
+        final_resp = follow_full_chain(session, login_resp)
+
+    # Collect cookies
+    cookies = collect_target_cookies(session)
+
+    if not cookies:
+        print(f"\nChain ended at: {final_resp.url}", file=sys.stderr)
+        print(f"Final status: {final_resp.status_code}", file=sys.stderr)
+        print("\nAll cookies:", file=sys.stderr)
+        for c in session.cookies:
+            print(f"  [{c.domain}] {c.name} = {c.value[:50]}...", file=sys.stderr)
+        die("Target cookies not found.")
+
+    print()
+    for name in TARGET_COOKIES:
+        if name in cookies:
+            print(f"{name}: {cookies[name]}")
+        else:
+            print(f"{name}: (not found)")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample-python-tool/auth-cli/requirements.txt
+++ b/sample-python-tool/auth-cli/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+beautifulsoup4>=4.12

--- a/src/Auth/Auth0Authenticator.php
+++ b/src/Auth/Auth0Authenticator.php
@@ -17,7 +17,7 @@ class Auth0Authenticator
     ];
     private const GOOGLE_AUTH_DOMAIN = 'pantheon-prodmirror.us.auth0.com';
     private const GOOGLE_AUTH_SPA_CLIENT_ID = 'eKOPHHW7lv1t7YuCiNk0BOpT2uIQLIBQ';
-    private const GOOGLE_AUTH_SRC = 'hermes-admin.sandbox-devx.sbx04.pantheon.io';
+    private const GOOGLE_AUTH_SRC = 'api.live.pantheon.io';
     private const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
         . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 

--- a/src/Auth/Auth0Authenticator.php
+++ b/src/Auth/Auth0Authenticator.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Pantheon\Terminus\Auth;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Psr\Http\Message\ResponseInterface;
+
+class Auth0Authenticator
+{
+    private const AUTH0_CONNECTION = 'Pantheon';
+    private const TARGET_COOKIES = ['X-Pantheon-Access-Token', 'X-Pantheon-Session'];
+    private const MAX_HOPS = 20;
+    private const AUTH0_DOMAINS = [
+        'dashboard.pantheon.io' => 'pantheon.auth0.com',
+    ];
+    private const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+        . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+    private string $hermesUrl;
+    private string $auth0Base;
+    private Client $client;
+    private CookieJar $cookieJar;
+
+    public function __construct(string $hermesUrl)
+    {
+        $this->hermesUrl = rtrim($hermesUrl, '/');
+
+        $host = parse_url($this->hermesUrl, PHP_URL_HOST);
+        $auth0Domain = self::AUTH0_DOMAINS[$host] ?? null;
+        if ($auth0Domain === null) {
+            throw new TerminusException(
+                'No Auth0 domain mapping for dashboard host {host}.',
+                ['host' => $host]
+            );
+        }
+        $this->auth0Base = "https://{$auth0Domain}";
+
+        $this->cookieJar = new CookieJar();
+        $this->client = new Client([
+            'cookies' => $this->cookieJar,
+            'allow_redirects' => false,
+            'timeout' => 30,
+            'http_errors' => false,
+            'headers' => [
+                'User-Agent' => self::USER_AGENT,
+            ],
+        ]);
+    }
+
+    /**
+     * Authenticate with email and password via Auth0.
+     *
+     * @return array{access_token: string, session: string}
+     *
+     * @throws TerminusException
+     */
+    public function login(string $email, string $password): array
+    {
+        $authorizeUrl = $this->getAuthorizeUrl();
+        if ($authorizeUrl === null) {
+            throw new TerminusException('Could not find Auth0 /authorize redirect.');
+        }
+
+        parse_str(parse_url($authorizeUrl, PHP_URL_QUERY) ?? '', $authParams);
+        $clientId = $authParams['client_id'] ?? null;
+
+        $loginTicket = $this->tryCrossOriginAuth($clientId, $email, $password);
+
+        if ($loginTicket !== null) {
+            $ticketUrl = $authorizeUrl
+                . '&login_ticket=' . urlencode($loginTicket)
+                . '&realm=' . urlencode(self::AUTH0_CONNECTION);
+            $response = $this->client->get($ticketUrl);
+            $this->followFullChain($response, $ticketUrl);
+        } else {
+            $response = $this->client->get($authorizeUrl);
+            [$loginPage, $loginPageUrl] = $this->followRedirects($response, $authorizeUrl);
+
+            $loginResponse = $this->tryUniversalLogin($loginPage, $loginPageUrl, $email, $password);
+            if ($loginResponse === null) {
+                throw new TerminusException('All login strategies failed.');
+            }
+            $this->followFullChain($loginResponse[0], $loginResponse[1]);
+        }
+
+        $cookies = $this->collectTargetCookies();
+        if (count($cookies) < count(self::TARGET_COOKIES)) {
+            $missing = array_diff(self::TARGET_COOKIES, array_keys($cookies));
+            throw new TerminusException(
+                'Authentication failed. Missing cookies: {missing}',
+                ['missing' => implode(', ', $missing)]
+            );
+        }
+
+        return [
+            'access_token' => $cookies['X-Pantheon-Access-Token'],
+            'session' => $cookies['X-Pantheon-Session'],
+        ];
+    }
+
+    private function collectTargetCookies(): array
+    {
+        $found = [];
+        foreach ($this->cookieJar as $cookie) {
+            if (in_array($cookie->getName(), self::TARGET_COOKIES, true)) {
+                $found[$cookie->getName()] = $cookie->getValue();
+            }
+        }
+        return $found;
+    }
+
+    /**
+     * Follow Hermes login redirect to capture the Auth0 /authorize URL.
+     */
+    private function getAuthorizeUrl(): ?string
+    {
+        $url = "{$this->hermesUrl}/auth/providers/any/login?destination=%2Fworkspace";
+        $response = $this->client->get($url);
+
+        for ($i = 0; $i < 10; $i++) {
+            $status = $response->getStatusCode();
+            if (!in_array($status, [301, 302, 303, 307, 308], true)) {
+                break;
+            }
+            $location = $response->getHeaderLine('Location');
+            $nextUrl = $this->resolveUrl($url, $location);
+            if (str_contains(parse_url($nextUrl, PHP_URL_PATH) ?? '', '/authorize')) {
+                return $nextUrl;
+            }
+            $url = $nextUrl;
+            $response = $this->client->get($url);
+        }
+
+        return null;
+    }
+
+    /**
+     * Strategy 1: Auth0 cross-origin authentication.
+     */
+    private function tryCrossOriginAuth(
+        ?string $clientId,
+        string $email,
+        string $password,
+    ): ?string {
+        if ($clientId === null) {
+            return null;
+        }
+
+        $response = $this->client->post("{$this->auth0Base}/co/authenticate", [
+            'json' => [
+                'client_id' => $clientId,
+                'credential_type' => 'http://auth0.com/oauth/grant-type/password-realm',
+                'username' => $email,
+                'password' => $password,
+                'realm' => self::AUTH0_CONNECTION,
+            ],
+            'headers' => [
+                'Origin' => $this->hermesUrl,
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        return $data['login_ticket'] ?? null;
+    }
+
+    /**
+     * Strategy 2: Auth0 New Universal Login form submission.
+     *
+     * @return array{ResponseInterface, string}|null Response and its URL, or null on failure.
+     */
+    private function tryUniversalLogin(
+        ResponseInterface $loginPage,
+        string $loginPageUrl,
+        string $email,
+        string $password,
+    ): ?array {
+        $state = $this->getQueryParam($loginPageUrl, 'state');
+        $pagePath = parse_url($loginPageUrl, PHP_URL_PATH) ?? '';
+
+        if (str_contains($pagePath, '/u/login/identifier')) {
+            $postUrl = "{$this->auth0Base}/u/login/identifier";
+            $idResponse = $this->client->post($postUrl, [
+                'form_params' => [
+                    'state' => $state,
+                    'username' => $email,
+                    'action' => 'default',
+                ],
+                'headers' => [
+                    'Origin' => $this->auth0Base,
+                    'Referer' => $loginPageUrl,
+                ],
+            ]);
+
+            if (!in_array($idResponse->getStatusCode(), [302, 303], true)) {
+                return null;
+            }
+
+            [$pwPage, $pwPageUrl] = $this->followRedirects($idResponse, $postUrl);
+            $pwPath = parse_url($pwPageUrl, PHP_URL_PATH) ?? '';
+
+            if (str_contains($pwPath, '/u/login/identifier')) {
+                return null;
+            }
+
+            $pwState = $this->getQueryParam($pwPageUrl, 'state') ?? $state;
+
+            $loginUrl = "{$this->auth0Base}/u/login";
+            $loginResp = $this->client->post($loginUrl, [
+                'form_params' => [
+                    'state' => $pwState,
+                    'username' => $email,
+                    'password' => $password,
+                    'action' => 'default',
+                ],
+                'headers' => [
+                    'Origin' => $this->auth0Base,
+                    'Referer' => $pwPageUrl,
+                ],
+            ]);
+
+            return [$loginResp, $loginUrl];
+        }
+
+        $loginUrl = "{$this->auth0Base}/u/login";
+        $loginResp = $this->client->post($loginUrl, [
+            'form_params' => [
+                'state' => $state,
+                'username' => $email,
+                'password' => $password,
+                'action' => 'default',
+            ],
+            'headers' => [
+                'Origin' => $this->auth0Base,
+                'Referer' => $loginPageUrl,
+            ],
+        ]);
+
+        return [$loginResp, $loginUrl];
+    }
+
+    /**
+     * Follow redirects and auto-submit HTML forms until settled or cookies found.
+     */
+    private function followFullChain(ResponseInterface $response, string $currentUrl): ResponseInterface
+    {
+        for ($i = 0; $i < self::MAX_HOPS; $i++) {
+            if (count($this->collectTargetCookies()) === count(self::TARGET_COOKIES)) {
+                return $response;
+            }
+
+            $status = $response->getStatusCode();
+
+            if (in_array($status, [301, 302, 303, 307, 308], true)) {
+                $location = $response->getHeaderLine('Location');
+                if (empty($location)) {
+                    return $response;
+                }
+                $currentUrl = $this->resolveUrl($currentUrl, $location);
+                $response = $this->client->get($currentUrl);
+                continue;
+            }
+
+            if ($status === 200 && str_contains($response->getHeaderLine('Content-Type'), 'text/html')) {
+                $form = $this->parseFirstForm($response->getBody()->getContents(), $currentUrl);
+                if ($form !== null) {
+                    $currentUrl = $form['action'];
+                    $response = $this->client->post($currentUrl, [
+                        'form_params' => $form['fields'],
+                    ]);
+                    continue;
+                }
+                return $response;
+            }
+
+            return $response;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Follow redirect responses (no form submission).
+     *
+     * @return array{ResponseInterface, string} The final response and its URL.
+     */
+    private function followRedirects(ResponseInterface $response, string $currentUrl, int $maxHops = 5): array
+    {
+        for ($i = 0; $i < $maxHops; $i++) {
+            if (!in_array($response->getStatusCode(), [301, 302, 303, 307, 308], true)) {
+                break;
+            }
+            $location = $response->getHeaderLine('Location');
+            $currentUrl = $this->resolveUrl($currentUrl, $location);
+            $response = $this->client->get($currentUrl);
+        }
+        return [$response, $currentUrl];
+    }
+
+    /**
+     * Parse the first HTML form in the body.
+     *
+     * @return array{action: string, fields: array<string, string>}|null
+     */
+    private function parseFirstForm(string $html, string $baseUrl): ?array
+    {
+        $doc = new \DOMDocument();
+        @$doc->loadHTML($html, LIBXML_NOERROR);
+        $forms = $doc->getElementsByTagName('form');
+        if ($forms->length === 0) {
+            return null;
+        }
+
+        $form = $forms->item(0);
+        $action = $form->getAttribute('action');
+        if (empty($action)) {
+            return null;
+        }
+
+        if (!str_starts_with($action, 'http')) {
+            $action = $this->resolveUrl($baseUrl, $action);
+        }
+
+        $fields = [];
+        $inputs = $form->getElementsByTagName('input');
+        for ($i = 0; $i < $inputs->length; $i++) {
+            $input = $inputs->item($i);
+            $name = $input->getAttribute('name');
+            if (!empty($name)) {
+                $fields[$name] = $input->getAttribute('value') ?? '';
+            }
+        }
+
+        return ['action' => $action, 'fields' => $fields];
+    }
+
+    /**
+     * Extract a query parameter from a URL.
+     */
+    private function getQueryParam(string $url, string $param): ?string
+    {
+        parse_str(parse_url($url, PHP_URL_QUERY) ?? '', $params);
+        return $params[$param] ?? null;
+    }
+
+    /**
+     * Resolve a possibly-relative URL against a base URL.
+     */
+    private function resolveUrl(string $baseUrl, string $relativeUrl): string
+    {
+        if (str_starts_with($relativeUrl, 'http')) {
+            return $relativeUrl;
+        }
+
+        $parsed = parse_url($baseUrl);
+        $base = ($parsed['scheme'] ?? 'https') . '://' . ($parsed['host'] ?? '');
+
+        if (str_starts_with($relativeUrl, '/')) {
+            return $base . $relativeUrl;
+        }
+
+        $basePath = $parsed['path'] ?? '/';
+        $dir = substr($basePath, 0, (int)strrpos($basePath, '/'));
+        return $base . $dir . '/' . $relativeUrl;
+    }
+}

--- a/src/Auth/Auth0Authenticator.php
+++ b/src/Auth/Auth0Authenticator.php
@@ -15,6 +15,9 @@ class Auth0Authenticator
     private const AUTH0_DOMAINS = [
         'dashboard.pantheon.io' => 'pantheon.auth0.com',
     ];
+    private const GOOGLE_AUTH_DOMAIN = 'pantheon-prodmirror.us.auth0.com';
+    private const GOOGLE_AUTH_SPA_CLIENT_ID = 'eKOPHHW7lv1t7YuCiNk0BOpT2uIQLIBQ';
+    private const GOOGLE_AUTH_SRC = 'hermes-admin.sandbox-devx.sbx04.pantheon.io';
     private const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
         . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -98,6 +101,74 @@ class Auth0Authenticator
             'access_token' => $cookies['X-Pantheon-Access-Token'],
             'session' => $cookies['X-Pantheon-Session'],
         ];
+    }
+
+    /**
+     * Build an Auth0 authorize URL for Google OAuth with PKCE.
+     *
+     * @return array{url: string, code_verifier: string, state: string, client_id: string}
+     */
+    public function getGoogleAuthUrl(string $callbackUrl): array
+    {
+        $clientId = self::GOOGLE_AUTH_SPA_CLIENT_ID;
+        $auth0Base = 'https://' . self::GOOGLE_AUTH_DOMAIN;
+
+        $codeVerifier = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+        $codeChallenge = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+        $state = http_build_query(['src' => self::GOOGLE_AUTH_SRC, 'nonce' => bin2hex(random_bytes(16))]);
+
+        $authUrl = $auth0Base . '/authorize?' . http_build_query([
+            'client_id' => $clientId,
+            'redirect_uri' => $callbackUrl,
+            'response_type' => 'code',
+            'connection' => 'google-oauth2',
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => 'S256',
+            'scope' => 'openid profile email',
+            'state' => $state,
+        ]);
+
+        return [
+            'url' => $authUrl,
+            'code_verifier' => $codeVerifier,
+            'state' => $state,
+            'client_id' => $clientId,
+            'auth0_base' => $auth0Base,
+        ];
+    }
+
+    /**
+     * Exchange an authorization code for tokens using PKCE.
+     *
+     * @return array Auth0 token response (access_token, id_token, etc.)
+     */
+    public function exchangeCodeForTokens(
+        string $code,
+        string $codeVerifier,
+        string $redirectUri,
+        string $clientId,
+        ?string $auth0Base = null,
+    ): array {
+        $tokenUrl = ($auth0Base ?? $this->auth0Base) . '/oauth/token';
+        $response = $this->client->post($tokenUrl, [
+            'json' => [
+                'grant_type' => 'authorization_code',
+                'client_id' => $clientId,
+                'code_verifier' => $codeVerifier,
+                'code' => $code,
+                'redirect_uri' => $redirectUri,
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            $body = $response->getBody()->getContents();
+            throw new TerminusException(
+                'Token exchange failed ({status}): {body}',
+                ['status' => $response->getStatusCode(), 'body' => $body]
+            );
+        }
+
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     private function collectTargetCookies(): array

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pantheon\Terminus\Commands\Auth;
 
+use Pantheon\Terminus\Auth\Auth0Authenticator;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\TerminusModel;
@@ -21,15 +22,22 @@ class LoginCommand extends TerminusCommand
      *
      * @option machine-token Grants access for a user and is saved for future logins
      * @option email Uses an existing machine token for this user
+     * @option password Log in with email and password via Auth0
      *
      * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
      * @usage Logs in a user with a previously saved machine token.
      * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
+     * @usage --password Logs in a user with email and password.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    public function logIn(array $options = ['machine-token' => null, 'email' => null,]): void
+    public function logIn(array $options = ['machine-token' => null, 'email' => null, 'password' => false,]): void
     {
+        if (!empty($options['password'])) {
+            $this->passwordLogIn($options['email'] ?? null);
+            return;
+        }
+
         $tokens = $this->session()->getTokens();
 
         if (isset($options['machine-token'])) {
@@ -69,6 +77,53 @@ class LoginCommand extends TerminusCommand
                     ['tokens' => implode("\n", $tokens->ids()), 'url' => $this->getMachineTokenCreationURL(),]
                 );
         }
+    }
+
+    /**
+     * Logs in via email and password through Auth0.
+     */
+    private function passwordLogIn(?string $email = null): void
+    {
+        $email = $email ?? $this->io()->ask('Email');
+        $password = $this->io()->askHidden('Password');
+
+        $hermesUrl = sprintf(
+            '%s://%s',
+            $this->config->get('dashboard_protocol'),
+            $this->config->get('dashboard_host'),
+        );
+
+        $authenticator = new Auth0Authenticator($hermesUrl);
+        $result = $authenticator->login($email, $password);
+
+        $userId = $this->extractUserIdFromAccessToken($result['access_token']);
+
+        $this->session()->setData([
+            'session' => $result['session'],
+            'expires_at' => time() + 86400,
+            'user_id' => $userId,
+        ]);
+
+        $this->log()->notice('Logged in via password.');
+    }
+
+    /**
+     * Decode the access token JWT and extract the Pantheon user ID.
+     */
+    private function extractUserIdFromAccessToken(string $accessToken): string
+    {
+        $parts = explode('.', $accessToken);
+        if (count($parts) < 2) {
+            throw new TerminusException('Access token is not a valid JWT.');
+        }
+
+        $payload = json_decode(base64_decode(strtr($parts[1], '-_', '+/')), true);
+        $userId = $payload['http://oidc.panth.io/pantheon']['user_id'] ?? null;
+        if (empty($userId)) {
+            throw new TerminusException('Access token does not contain a user ID.');
+        }
+
+        return $userId;
     }
 
     /**

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -6,6 +6,7 @@ use Pantheon\Terminus\Auth\Auth0Authenticator;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\TerminusModel;
+use Symfony\Component\Process\Process;
 
 /**
  * Class LoginCommand.
@@ -23,16 +24,23 @@ class LoginCommand extends TerminusCommand
      * @option machine-token Grants access for a user and is saved for future logins
      * @option email Uses an existing machine token for this user
      * @option password Log in with email and password via Auth0
+     * @option google Log in with Google via Auth0
      *
      * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
      * @usage Logs in a user with a previously saved machine token.
      * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
      * @usage --password Logs in a user with email and password.
+     * @usage --google Logs in a user with Google OAuth.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    public function logIn(array $options = ['machine-token' => null, 'email' => null, 'password' => false,]): void
+    public function logIn(array $options = ['machine-token' => null, 'email' => null, 'password' => false, 'google' => false,]): void
     {
+        if (!empty($options['google'])) {
+            $this->googleLogIn();
+            return;
+        }
+
         if (!empty($options['password'])) {
             $this->passwordLogIn($options['email'] ?? null);
             return;
@@ -100,11 +108,189 @@ class LoginCommand extends TerminusCommand
 
         $this->session()->setData([
             'session' => $result['session'],
+            'access_token' => $result['access_token'],
             'expires_at' => time() + 86400,
             'user_id' => $userId,
         ]);
 
         $this->log()->notice('Logged in via password.');
+    }
+
+    /**
+     * Logs in via Google OAuth through Auth0 using PKCE.
+     */
+    private function googleLogIn(): void
+    {
+        $hermesUrl = sprintf(
+            '%s://%s',
+            $this->config->get('dashboard_protocol'),
+            $this->config->get('dashboard_host'),
+        );
+
+        $authenticator = new Auth0Authenticator($hermesUrl);
+
+        $port = $this->findOAuthPort();
+        $callbackUrl = "http://localhost:{$port}/auth/callback";
+
+        $authInfo = $authenticator->getGoogleAuthUrl($callbackUrl);
+
+        [$serverScript, $dataFile] = $this->createOAuthServerScript($authInfo['state']);
+        $serverProcess = new Process(['php', '-S', "localhost:{$port}", $serverScript]);
+        $serverProcess->start();
+
+        try {
+            $this->log()->notice('Opening Google login in your browser...');
+            $this->log()->notice('If your browser does not open, visit this URL:');
+            $this->log()->notice($authInfo['url']);
+
+            $this->openBrowser($authInfo['url']);
+
+            $code = $this->waitForOAuthCallback($dataFile, 120);
+
+            $tokens = $authenticator->exchangeCodeForTokens(
+                $code,
+                $authInfo['code_verifier'],
+                $callbackUrl,
+                $authInfo['client_id'],
+                $authInfo['auth0_base'] ?? null,
+            );
+
+            $idToken = $tokens['id_token'] ?? null;
+            if (empty($idToken)) {
+                throw new TerminusException('No id_token in Auth0 response.');
+            }
+
+            $userId = $this->extractUserIdFromJwt($idToken);
+
+            $this->session()->setData([
+                'access_token' => $tokens['access_token'] ?? null,
+                'expires_at' => time() + ($tokens['expires_in'] ?? 86400),
+                'user_id' => $userId,
+            ]);
+
+            $this->log()->notice('Logged in via Google.');
+        } finally {
+            $serverProcess->stop(0);
+        }
+    }
+
+    private function openBrowser(string $url): void
+    {
+        $cmd = match (php_uname('s')) {
+            'Linux' => 'xdg-open',
+            'Darwin' => 'open',
+            'Windows NT' => 'start',
+            default => null,
+        };
+        if ($cmd === null) {
+            $this->log()->warning('Cannot open browser automatically on this OS.');
+            return;
+        }
+        (new Process([$cmd, $url]))->start();
+    }
+
+    private function findOAuthPort(): int
+    {
+        foreach ([3000, 4000] as $port) {
+            $socket = @stream_socket_server("tcp://127.0.0.1:{$port}");
+            if ($socket !== false) {
+                fclose($socket);
+                return $port;
+            }
+        }
+        throw new TerminusException('Ports 3000 and 4000 are both in use. Free one to continue.');
+    }
+
+    /**
+     * Create a PHP server script that captures the OAuth authorization code.
+     *
+     * @return array{string, string} Server script path and data file path.
+     */
+    private function createOAuthServerScript(string $expectedState): array
+    {
+        $token = bin2hex(random_bytes(8));
+        $scriptPath = sys_get_temp_dir() . "/terminus_oauth_server_{$token}.php";
+        $dataFile = sys_get_temp_dir() . "/terminus_oauth_data_{$token}";
+
+        $php = <<<'SERVERSCRIPT'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (strpos($uri, '/auth/callback') !== 0) {
+    http_response_code(404);
+    echo 'Not found';
+    exit;
+}
+parse_str($_SERVER['QUERY_STRING'] ?? '', $query);
+$state = $query['state'] ?? '';
+$code = $query['code'] ?? '';
+$error = $query['error'] ?? '';
+$errorDesc = $query['error_description'] ?? '';
+if ($state !== 'EXPECTED_STATE') {
+    http_response_code(403);
+    echo 'Invalid state parameter.';
+    exit;
+}
+if ($error) {
+    file_put_contents('DATA_FILE', json_encode(['error' => $error, 'error_description' => $errorDesc]));
+} else {
+    file_put_contents('DATA_FILE', json_encode(['code' => $code]));
+}
+header('Content-Type: text/html');
+echo '<html><body><h2>Authentication successful.</h2><p>You can close this window and return to the terminal.</p></body></html>';
+SERVERSCRIPT;
+
+        $php = str_replace('EXPECTED_STATE', addslashes($expectedState), $php);
+        $php = str_replace('DATA_FILE', addslashes($dataFile), $php);
+
+        file_put_contents($scriptPath, $php);
+        return [$scriptPath, $dataFile];
+    }
+
+    /**
+     * Wait for the OAuth callback to write the authorization code.
+     */
+    private function waitForOAuthCallback(string $dataFile, int $timeoutSeconds): string
+    {
+        $start = time();
+        while (true) {
+            if (file_exists($dataFile)) {
+                $data = json_decode(file_get_contents($dataFile), true);
+                unlink($dataFile);
+                if (isset($data['error'])) {
+                    throw new TerminusException(
+                        'OAuth error: {error} - {description}',
+                        ['error' => $data['error'], 'description' => $data['error_description'] ?? '']
+                    );
+                }
+                if (!empty($data['code'])) {
+                    return $data['code'];
+                }
+                throw new TerminusException('OAuth callback did not include an authorization code.');
+            }
+            if ((time() - $start) > $timeoutSeconds) {
+                throw new TerminusException('Google login timed out waiting for browser authentication.');
+            }
+            usleep(500000);
+        }
+    }
+
+    /**
+     * Extract the Pantheon user ID from an Auth0 JWT access token.
+     */
+    private function extractUserIdFromJwt(string $jwt): string
+    {
+        $parts = explode('.', $jwt);
+        if (count($parts) < 2) {
+            throw new TerminusException('Access token is not a valid JWT.');
+        }
+
+        $payload = json_decode(base64_decode(strtr($parts[1], '-_', '+/')), true);
+        $userId = $payload['http://oidc.panth.io/pantheon']['user_id'] ?? null;
+        if (empty($userId)) {
+            throw new TerminusException('Access token does not contain a Pantheon user ID.');
+        }
+
+        return $userId;
     }
 
     /**

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -96,7 +96,7 @@ class LoginCommand extends TerminusCommand
         $authenticator = new Auth0Authenticator($hermesUrl);
         $result = $authenticator->login($email, $password);
 
-        $userId = $this->extractUserIdFromAccessToken($result['access_token']);
+        $userId = $this->extractUserIdFromSession($result['session']);
 
         $this->session()->setData([
             'session' => $result['session'],
@@ -108,22 +108,16 @@ class LoginCommand extends TerminusCommand
     }
 
     /**
-     * Decode the access token JWT and extract the Pantheon user ID.
+     * Extract the user ID from the session token (everything before the first ':').
      */
-    private function extractUserIdFromAccessToken(string $accessToken): string
+    private function extractUserIdFromSession(string $session): string
     {
-        $parts = explode('.', $accessToken);
-        if (count($parts) < 2) {
-            throw new TerminusException('Access token is not a valid JWT.');
+        $decoded = urldecode($session);
+        $colonPos = strpos($decoded, ':');
+        if ($colonPos === false) {
+            throw new TerminusException('Session token does not contain a user ID.');
         }
-
-        $payload = json_decode(base64_decode(strtr($parts[1], '-_', '+/')), true);
-        $userId = $payload['http://oidc.panth.io/pantheon']['user_id'] ?? null;
-        if (empty($userId)) {
-            throw new TerminusException('Access token does not contain a user ID.');
-        }
-
-        return $userId;
+        return substr($decoded, 0, $colonPos);
     }
 
     /**

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -118,8 +118,9 @@ class Session implements
     public function isActive()
     {
         // Consider a session expired if it is already about to expire (less than 1 minute).
+        $hasToken = isset($this->data->session) || isset($this->data->access_token);
         return (
-            isset($this->data->session)
+            $hasToken
             && ($this->data->expires_at >= (time() + 60) || (bool)$this->config->get(
                 'test_mode'
             ))


### PR DESCRIPTION
This code demonstrated fetching a jwt via an email/password login. Only the session token is used for now, but the jwt is available.

This is suitable for:

 - Development with jwt sessions (Terminus and other features)
 - `terminus auth:login` without machine tokens

Do not merge. Could be enhanced at some point to provide better authentication mechanisms with the same jwt capability.

n.b. Also includes a python script that does the same thing. This is definitely not intended for Terminus; it is only for demonstration purposes.

With https://github.com/pantheon-systems/pantheonapi/pull/443/changes, Terminus can authenticate with pantheonapi using a modern JWT.