### PR TITLE
[DEVX-6989] Add nightly schedule and conditional parallelization for tests

### DIFF
--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -1,6 +1,9 @@
 name: Terminus 4.x
 on:
   push:
+  schedule:
+    # Run nightly at 2:17 AM UTC (avoid :00 and :30 to reduce API load)
+    - cron: '17 2 * * *'
   workflow_dispatch:
     inputs:
       functional_tests_group:
@@ -59,6 +62,9 @@ jobs:
       matrix:
         operating-system: [ 'macos-latest' ]
         php-versions: [ '8.2', '8.5' ]
+      # Run sequentially on schedule (nightly) to avoid race conditions with site-level operations
+      # Run in parallel on push (PRs) for faster feedback
+      max-parallel: ${{ github.event_name == 'schedule' && 1 || 2 }}
     env:
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
       TERMINUS_SITE: ${{ vars.TERMINUS_SITE }}


### PR DESCRIPTION
## Summary
Adds nightly schedule trigger and conditional parallelization to prevent race conditions on site-level operations.

## Context
After merging #2875 (parallelization), we discovered:
- The "long" test suite (solr/redis/NR enable/disable) was supposed to run nightly
- But there was **no schedule trigger** configured in the workflow
- These tests have never been running automatically
- The parallelization applies to ALL tests when they do run, which could cause race conditions on site-level operations

## Changes
1. **Added nightly schedule**: Runs at 2:17 AM UTC (avoiding :00/:30 to reduce API load)
2. **Conditional parallelization**: 
   - PRs (push events): `max-parallel: 2` - runs short tests in parallel for fast feedback
   - Nightly (schedule): `max-parallel: 1` - runs all tests (short + long) sequentially to avoid race conditions

## Testing
- [ ] Manual workflow_dispatch run with "all" triggered to verify long tests work
- [ ] Will monitor first nightly run

🤖