### PR TITLE
fix(DEVX-7129): resolve getConfig() error in LockHandlingCommand hook

### DIFF
--- a/src/VcsApi/VcsClientAwareTrait.php
+++ b/src/VcsApi/VcsClientAwareTrait.php
@@ -29,7 +29,7 @@ trait VcsClientAwareTrait
             return $this->vcsClient;
         }
 
-        $polling_interval = $this->getConfig()->get('http_retry_delay_ms', 1000);
+        $polling_interval = $this->request()->getConfig()->get('http_retry_delay_ms', 1000);
 
         return $this->vcsClient = new Client($this->request(), $polling_interval);
     }


### PR DESCRIPTION
## Summary
- Fix `Call to undefined method LockHandlingCommand::getConfig()` fatal error triggered after accepting rebuild prompt during `lock:enable`
- `VcsClientAwareTrait` called `$this->getConfig()` which only exists on Robo command classes — `LockHandlingCommand` is a standalone hook handler that doesn't extend `TerminusCommand`, so it lacks that method
- Changed to `$this->request()->getConfig()` which is available via `RequestAwareTrait` already included in the trait

## Test plan
- [ ] Run `lock:enable` on a Node.js site and accept the rebuild prompt — should no longer fatal
- [ ] Run `lock:disable` on a Node.js site with rebuild — verify same fix applies
- [ ] Verify other commands using `VcsClientAwareTrait` still work (e.g., `vcs:connection:add`, `site:create`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)