### PR TITLE
ci: add brew trust step for Homebrew release packaging

### DIFF
--- a/.github/workflows/4.x.yml
+++ b/.github/workflows/4.x.yml
@@ -148,6 +148,10 @@ jobs:
     needs: [ release ]
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
     steps:
+      - name: Trust Homebrew tap
+        run: |
+          brew tap pantheon-systems/external
+          brew trust pantheon-systems/external
       - name: Bump Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@baf2b60c51fc1f8453c884b0c61052668a71bd1d # v3.11.0
         with:


### PR DESCRIPTION
The Homebrew formula bump step in the release workflow fails because Homebrew now requires taps to be explicitly trusted before loading formulas.

This adds a `brew trust pantheon-systems/external` step before the formula bump action.

**Note:** This can only be verified on the next actual release since the Homebrew job only runs on tag pushes.

Context: 4.3.2 release Homebrew step failed with `Homebrew::UntrustedTapError`.