### PR TITLE
fix: write audit.block-insecure=false directly to terminus-dependenci…

### DIFF
--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -369,8 +369,25 @@ abstract class PluginBaseCommand extends TerminusCommand
             $this->runCommand("composer --working-dir=$path init --name=$package_name -n");
             $this->runCommand("composer --working-dir=$path config minimum-stability dev");
             $this->runCommand("composer --working-dir=$path config prefer-stable true");
-            $this->runCommand("composer --working-dir=$path config audit.block-insecure false");
         }
+        // Setting audit.block-insecure via the config command is not supported in all Composer
+        // versions (composer/composer#12611). Writing directly to the JSON is more reliable
+        // across the range of Composer versions terminus supports. Decode without associative
+        // mode to preserve the object/array distinction and avoid corrupting empty object keys
+        // such as "require": {} into JSON arrays.
+        $composerJsonPath = $path . '/composer.json';
+        $composerJson = json_decode(file_get_contents($composerJsonPath)) ?? new \stdClass();
+        if (!isset($composerJson->config)) {
+            $composerJson->config = new \stdClass();
+        }
+        if (!isset($composerJson->config->audit)) {
+            $composerJson->config->audit = new \stdClass();
+        }
+        $composerJson->config->audit->{'block-insecure'} = false;
+        file_put_contents(
+            $composerJsonPath,
+            json_encode($composerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

`self:plugin:refresh` (and all plugin commands that trigger dependency resolution) fail
with a Composer audit error when any package pinned in terminus's `composer.lock` carries
a current security advisory:

these were not loaded, because they are affected by security advisories

This regression first appeared with Composer 2.9.0, which introduced `audit.block-insecure`
— blocking installs of packages with known CVEs by default.

## Root cause

Two bugs in `PluginBaseCommand::ensureComposerJsonExists()`:

**1. Wrong scope**

The setting was inside the `if (!composer.json exists)` block, so it only ran when the
file was first created. On subsequent runs, the existing `terminus-dependencies` directory
is mirrored into a temp dir — the file already exists, the block is skipped, and the
setting is never applied to the copied file.

**2. The command doesn't work**

`composer config audit.block-insecure false` is not supported as a config key in older
Composer versions ([composer/composer#12611](https://github.com/composer/composer/issues/12611)).
It exits with an error that was never surfaced because `ensureComposerJsonExists` doesn't
check return codes. The setting was therefore never written, even on first creation.

## Fix

Write `audit.block-insecure: false` directly into `composer.json` via
`json_decode`/`json_encode` after the init block. This:

- Runs unconditionally — covers both freshly created and mirrored-from-existing files
- Works across all Composer versions terminus supports, independent of `config` command
  support for this key

`json_decode()` is called without associative mode to preserve the object/array
distinction in existing JSON and avoid corrupting keys such as `"require": {}` into arrays.

## Testing

Confirmed `terminus self:plugin:refresh` completes successfully with:
- Composer 2.9.1 ✓
- Composer 2.10.1 ✓

## Notes

- The `audit` config section is deprecated in Composer 2.10.0 in favour of a new `policy`
  config. `audit.block-insecure` continues to work in 2.10.x for now, but may be dropped
  in a future Composer major version.
- Composer 2.9.0–2.9.7 carries known security vulnerabilities (command injection patched
  in 2.9.6; token disclosure patched in 2.9.8). The current terminus minimum of Composer
  2.1.0 may be worth revisiting separately.

Fixes #2847