### PR TITLE
fix: write composer audit.block-insecure directly to composer.json

### DIFF
--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -365,12 +365,49 @@ abstract class PluginBaseCommand extends TerminusCommand
     protected function ensureComposerJsonExists($path, $package_name)
     {
         $this->ensureDirectoryExists($path);
-        if (!$this->getLocalMachine()->getFileSystem()->exists($path . '/composer.json')) {
+        $composer_json_path = $path . '/composer.json';
+        if (!$this->getLocalMachine()->getFileSystem()->exists($composer_json_path)) {
             $this->runCommand("composer --working-dir=$path init --name=$package_name -n");
             $this->runCommand("composer --working-dir=$path config minimum-stability dev");
             $this->runCommand("composer --working-dir=$path config prefer-stable true");
-            $this->runCommand("composer --working-dir=$path config audit.block-insecure false");
         }
+        // Re-applied even for a pre-existing composer.json, since older Terminus
+        // versions could have created one without this setting (see method docblock).
+        $this->disableComposerInsecurePackageAudit($composer_json_path);
+    }
+
+    /**
+     * Disables Composer's insecure-package audit block in the given composer.json.
+     *
+     * Composer's "config" command does not support setting "audit.block-insecure"
+     * (only "audit.abandoned" and "audit.ignore" are wired up as settable keys),
+     * even though it is a valid composer.json schema key that defaults to true.
+     * Attempting "composer config audit.block-insecure false" fails, so the
+     * setting has to be written into composer.json directly instead.
+     *
+     * @param string $composer_json_path Path to the composer.json file to update.
+     *
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    protected function disableComposerInsecurePackageAudit($composer_json_path)
+    {
+        $local_machine = $this->getLocalMachine();
+        // Decoded as objects (not associative arrays) so that empty JSON objects
+        // already in the file, e.g. "require": {}, don't get flattened into "[]"
+        // on re-encode, which Composer's schema validation rejects.
+        $composer_json = json_decode($local_machine->readFile($composer_json_path)) ?: new \stdClass();
+        if (!isset($composer_json->config)) {
+            $composer_json->config = new \stdClass();
+        }
+        if (!isset($composer_json->config->audit)) {
+            $composer_json->config->audit = new \stdClass();
+        }
+        $composer_json->config->audit->{'block-insecure'} = false;
+        $local_machine->writeFile(
+            $composer_json_path,
+            json_encode($composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- `terminus plugin:install`/`update` generate a temp `composer.json` and try to disable Composer's insecure-package audit block via `composer config audit.block-insecure false`. On current Composer versions that CLI call is rejected (`Setting audit.block-insecure does not exist or is not supported by this command`) because only `audit.abandoned` and `audit.ignore` are wired up as settable keys in Composer's `config` command — `block-insecure` is still a fully valid and enforced `composer.json` schema key (default `true`), it just isn't settable through that particular CLI shortcut.
- The failing call's exit code was never checked, so the setting silently never got applied, and any plugin dependency version with an open security advisory (e.g. the current pins for `guzzlehttp/guzzle` and `guzzlehttp/psr7`) caused the whole install to fail.
- This writes `config.audit.block-insecure = false` directly into `composer.json` instead of relying on the unsupported CLI setter, and re-applies it even when `composer.json` already exists so previously-created dependency directories pick up the fix too.

## Test plan
- [x] Verified `composer config audit.block-insecure false` fails on Composer 2.9.1 with the exact error seen in the field
- [x] Verified manually writing `config.audit.block-insecure` into `composer.json` allows `composer require` of the exact pinned/advisory-flagged versions to succeed
- [x] Confirmed the object-decode approach avoids corrupting empty JSON objects (e.g. `"require": {}`) into arrays, which would otherwise fail Composer's schema validation
- [x] `php -l` and `vendor/bin/phpcs --standard=phpcs_ruleset.xml` pass on the changed file
- [x] Ran `bin/terminus plugin:install terminus-autopilot-plugin` against this branch — installs successfully; `terminus plugin:remove terminus-autopilot-plugin` cleans up successfully