### PR TITLE
Fix getUser error messages

### DIFF
--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -87,7 +87,7 @@ class Session implements
         $user = $this->getContainer()->get($nickname);
         if (!$user instanceof User) {
             throw new TerminusException(
-                "No User ID. Please ling via terminus auth:login"
+                "No user ID. Please login via terminus auth:login"
             );
         }
         return $user;


### PR DESCRIPTION
Fixes a typo in "login" and makes the two messages the same in Session::getUser().