### PR TITLE
feat(DEVX-7422): Automatically refresh tokens that expire during a long command execution.

### DIFF
--- a/src/Hooks/Authorizer.php
+++ b/src/Hooks/Authorizer.php
@@ -28,17 +28,7 @@ class Authorizer implements ConfigAwareInterface, SessionAwareInterface
     public function ensureLogin()
     {
         if (!$this->session()->isActive()) {
-            $tokens_obj = $this->session()->getTokens();
-            if (count($tokens = $tokens_obj->all()) == 1) {
-                $token = array_shift($tokens);
-            } elseif (!empty($email = $this->getConfig()->get('user'))) {
-                $token = $tokens_obj->get($email);
-            } else {
-                throw new TerminusException(
-                    'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
-                );
-            }
-            $token->logIn();
+            $this->session()->getAuthToken()->logIn();
         }
     }
 }

--- a/src/Models/SavedToken.php
+++ b/src/Models/SavedToken.php
@@ -42,6 +42,7 @@ class SavedToken extends TerminusModel implements
      * Starts a session with this saved token
      *
      * @return User An object representing the now-logged-in user
+     * @throws TerminusException If the machine token is rejected
      */
     public function logIn()
     {
@@ -52,10 +53,18 @@ class SavedToken extends TerminusModel implements
             ],
             'method' => 'post',
         ];
-        $response = $this->request->request(
+        // Bypass Request::request()'s 401 refresh-and-retry: this call IS the
+        // refresh operation, so it must never trigger a nested refresh attempt.
+        $response = $this->request->requestWithoutRefreshHandling(
             'authorize/machine-token',
             $options
         );
+        if ($response->getStatusCode() !== 200) {
+            throw new TerminusException(
+                'Could not log in with the given machine token: {reason}',
+                ['reason' => $response->getStatusCodeReason()]
+            );
+        }
         $this->session()->setData((array)$response['data']);
         return $this->session->getUser();
     }

--- a/src/Models/SavedToken.php
+++ b/src/Models/SavedToken.php
@@ -46,10 +46,16 @@ class SavedToken extends TerminusModel implements
      */
     public function logIn()
     {
+        // Pass the machine token to PantheonAPI. We include a
+        // marker field to indicate that this version of Terminus
+        // supports refreshing session tokens during command
+        // execution to avoid rejection once old Terminus versions
+        // are discontinued.
         $options = [
             'form_params' => [
                 'machine_token' => $this->get('token'),
                 'client' => 'terminus',
+                'is_short_ttl_capable' => true,
             ],
             'method' => 'post',
         ];

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -249,11 +249,12 @@ class Request implements
                     //     follows these itself; retrying one is meaningless).
                     //   - 400, 404, 405, 406      - permanent client errors (bad request, not
                     //                               found, method not allowed, not acceptable).
-                    //   - 401 Unauthorized        - Terminus refreshes the session proactively
-                    //                               before every command (Authorizer::ensureLogin(),
-                    //                               Session::isActive()); a 401 that still occurs
-                    //                               means the credentials are invalid/revoked, and
-                    //                               retrying the identical request cannot fix that.
+                    //   - 401 Unauthorized        - Terminus refreshes the session proactively before
+                    //                               every command (Authorizer::ensureLogin()) and
+                    //                               reactively on a mid-command 401 (Request::request()'s
+                    //                               refresh-and-retry-once, see refreshSession()); a 401
+                    //                               that survives both means credentials are invalid or
+                    //                               revoked, and retrying again cannot fix that.
                     //   - 403 Forbidden           - permanent authorization denial, never retried.
                     //   - 409 Conflict            - handled specially below (may throw
                     //                               TerminusUnsupportedSiteException).
@@ -381,7 +382,8 @@ class Request implements
     }
 
     /**
-     * Simplified request method for Pantheon API.
+     * Simplified request method for Pantheon API. On a 401 Unauthorized response,
+     * attempts to refresh the session once and retries the request a single time.
      *
      * @param string $path API path (URL)
      * @param array $options Options for the request
@@ -394,6 +396,52 @@ class Request implements
      * @throws TerminusException
      */
     public function request($path, array $options = []): RequestOperationResult
+    {
+        $result = $this->requestWithoutRefreshHandling($path, $options);
+
+        if ($result->getStatusCode() === 401 && $this->refreshSession()) {
+            $result = $this->requestWithoutRefreshHandling($path, $options);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Attempts to refresh the current session by re-authenticating with the saved
+     * machine token. Used to recover from a session that expired mid-command.
+     *
+     * @return bool True if the session was refreshed successfully.
+     */
+    private function refreshSession(): bool
+    {
+        try {
+            $this->session()->getAuthToken()->logIn();
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Session refresh failed after receiving a 401: {message}',
+                ['message' => $e->getMessage()]
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Sends a request to the Pantheon API without any 401 refresh-and-retry handling.
+     * Used directly by SavedToken::logIn(), since that call IS the refresh operation
+     * and must never trigger a nested refresh attempt.
+     *
+     * @param string $path API path (URL)
+     * @param array $options Options for the request
+     *   string method      GET is default
+     *   array form_params  Fed into the body of the request
+     *
+     * @return RequestOperationResult
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws TerminusException
+     */
+    public function requestWithoutRefreshHandling($path, array $options = []): RequestOperationResult
     {
         $config = $this->getConfig();
 

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -166,6 +166,16 @@ class Request implements
     }
 
     /**
+     * Wraps the global sleep() so tests can override retry delays.
+     *
+     * @param int $seconds
+     */
+    protected function sleep(int $seconds): void
+    {
+        sleep($seconds);
+    }
+
+    /**
      * Returns the Retry Decider middleware.
      *
      * @return callable
@@ -221,7 +231,7 @@ class Request implements
                 if ($retry !== $maxRetries) {
                     $logWarningOnRetry($exception->getMessage());
                     $logWarning(sprintf("Retrying in %s seconds.", $retryBackoff * ($retry + 1)));
-                    sleep($retryBackoff * ($retry + 1));
+                    $this->sleep($retryBackoff * ($retry + 1));
 
                     return true;
                 }
@@ -231,22 +241,47 @@ class Request implements
                     ['error' => $exception->getMessage()]
                 );
             } else {
-                if (preg_match('/[2,4]0\d/', $response->getStatusCode())) {
-                    // Do not retry on 20x or 40x responses.
+                $statusCode = $response->getStatusCode();
+
+                if (!RetryPolicy::isRetryableStatusCode($statusCode)) {
+                    // Non-retryable response. This includes:
+                    //   - 2xx success (nothing to retry) and 3xx redirects (Guzzle normally
+                    //     follows these itself; retrying one is meaningless).
+                    //   - 400, 404, 405, 406      - permanent client errors (bad request, not
+                    //                               found, method not allowed, not acceptable).
+                    //   - 401 Unauthorized        - Terminus refreshes the session proactively
+                    //                               before every command (Authorizer::ensureLogin(),
+                    //                               Session::isActive()); a 401 that still occurs
+                    //                               means the credentials are invalid/revoked, and
+                    //                               retrying the identical request cannot fix that.
+                    //   - 403 Forbidden           - permanent authorization denial, never retried.
+                    //   - 409 Conflict            - handled specially below (may throw
+                    //                               TerminusUnsupportedSiteException).
+                    //   - 410-431, 451            - permanent client errors (Gone, Payload Too
+                    //                               Large, Unprocessable Entity, Locked, legal
+                    //                               block, etc.) — retrying won't change them.
+                    //   - 501, 505-511            - permanent server-side/config failures.
+                    // See RetryPolicy::RETRYABLE_STATUS_CODES for the transient codes that ARE
+                    // retried below (408, 429, 500, 502, 503, 504).
                     return false;
                 }
 
                 if ($retry !== $maxRetries) {
-                    $logWarningOnRetry(
-                        sprintf('status code - %s', $response->getStatusCode())
-                    );
+                    $reason = RetryPolicy::isRateLimit($statusCode)
+                        ? 'rate limit exceeded (HTTP 429 Too Many Requests)'
+                        : sprintf('status code - %s', $statusCode);
+                    // Rate limits back off exponentially; other retryable codes keep the
+                    // existing linear backoff. See RetryPolicy::backoffSeconds().
+                    $delay = RetryPolicy::backoffSeconds($statusCode, $retryBackoff, $retry);
+
+                    $logWarningOnRetry($reason);
                     $this->logger->debug(
                         'Response body: {body}',
                         ['body' => $response->getBody()->getContents()]
                     );
 
-                    $logWarning(sprintf("Retrying in %s seconds.", $retryBackoff * ($retry + 1)));
-                    sleep($retryBackoff * ($retry + 1));
+                    $logWarning(sprintf("Retrying in %s seconds.", $delay));
+                    $this->sleep($delay);
 
                     return true;
                 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -249,6 +249,9 @@ class Request implements
                     //     follows these itself; retrying one is meaningless).
                     //   - 400, 404, 405, 406      - permanent client errors (bad request, not
                     //                               found, method not allowed, not acceptable).
+                    //   - 408 Request Timeout     - historically has not been retried; some operations
+                    //                               might not be idempotent and therefore not safe
+                    //                               to blindly retry.
                     //   - 401 Unauthorized        - Terminus refreshes the session proactively before
                     //                               every command (Authorizer::ensureLogin()) and
                     //                               reactively on a mid-command 401 (Request::request()'s
@@ -263,7 +266,7 @@ class Request implements
                     //                               block, etc.) — retrying won't change them.
                     //   - 501, 505-511            - permanent server-side/config failures.
                     // See RetryPolicy::RETRYABLE_STATUS_CODES for the transient codes that ARE
-                    // retried below (408, 429, 500, 502, 503, 504).
+                    // retried below (429, 500, 502, 503, 504).
                     return false;
                 }
 

--- a/src/Request/RetryPolicy.php
+++ b/src/Request/RetryPolicy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Pantheon\Terminus\Request;
+
+/**
+ * Class RetryPolicy
+ *
+ * Default-deny status-code retry policy: only status codes that represent a
+ * transient failure belong in RETRYABLE_STATUS_CODES. Adding a code here means
+ * "retrying the identical request, unmodified, is expected to eventually
+ * succeed." Anything else — including every commonly-seen permanent client or
+ * server error — must NOT be added; see the comment in
+ * Request::createRetryDecider() for the full rationale per code.
+ *
+ * @package Pantheon\Terminus\Request
+ */
+final class RetryPolicy
+{
+    public const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+
+    public const RATE_LIMIT_STATUS_CODE = 429;
+
+    /**
+     * @param int $statusCode
+     * @return bool
+     */
+    public static function isRetryableStatusCode(int $statusCode): bool
+    {
+        return in_array($statusCode, self::RETRYABLE_STATUS_CODES, true);
+    }
+
+    /**
+     * @param int $statusCode
+     * @return bool
+     */
+    public static function isRateLimit(int $statusCode): bool
+    {
+        return $statusCode === self::RATE_LIMIT_STATUS_CODE;
+    }
+
+    /**
+     * Number of seconds to wait before the given retry attempt. Rate limits get an
+     * exponential backoff, since a fixed/linear delay is unlikely to clear a 429 in time;
+     * every other retryable status code keeps the existing linear backoff.
+     *
+     * @param int $statusCode
+     * @param int $retryBackoff Base backoff, in seconds (from the 'http_retry_backoff' config).
+     * @param int $retry Zero-indexed retry attempt number.
+     * @return int
+     */
+    public static function backoffSeconds(int $statusCode, int $retryBackoff, int $retry): int
+    {
+        if (self::isRateLimit($statusCode)) {
+            return $retryBackoff * (2 ** ($retry + 1));
+        }
+        return $retryBackoff * ($retry + 1);
+    }
+}

--- a/src/Request/RetryPolicy.php
+++ b/src/Request/RetryPolicy.php
@@ -16,7 +16,7 @@ namespace Pantheon\Terminus\Request;
  */
 final class RetryPolicy
 {
-    public const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+    public const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
 
     public const RATE_LIMIT_STATUS_CODE = 429;
 

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -10,6 +10,7 @@ use Pantheon\Terminus\DataStore\DataStoreAwareInterface;
 use Pantheon\Terminus\DataStore\DataStoreAwareTrait;
 use Pantheon\Terminus\DataStore\DataStoreInterface;
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Models\SavedToken;
 use Pantheon\Terminus\Models\User;
 use Robo\Contract\ConfigAwareInterface;
 
@@ -135,6 +136,27 @@ class Session implements
     {
         $this->getDataStore()->set('session', $data);
         $this->data = (object)$data;
+    }
+
+    /**
+     * Selects the SavedToken to (re-)authenticate with: a single saved token, or
+     * the token matching the configured 'user' email.
+     *
+     * @return SavedToken
+     * @throws TerminusException If there is no unambiguous token to use.
+     */
+    public function getAuthToken(): SavedToken
+    {
+        $tokens_obj = $this->getTokens();
+        if (count($tokens = $tokens_obj->all()) == 1) {
+            return array_shift($tokens);
+        }
+        if (!empty($email = $this->getConfig()->get('user'))) {
+            return $tokens_obj->get($email);
+        }
+        throw new TerminusException(
+            'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
+        );
     }
 
     /**

--- a/tests/Unit/FastRequest.php
+++ b/tests/Unit/FastRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use Pantheon\Terminus\Request\Request;
+
+/**
+ * A Request subclass that skips real sleep()s so retry tests run instantly.
+ */
+class FastRequest extends Request
+{
+    public array $sleptSeconds = [];
+
+    protected function sleep(int $seconds): void
+    {
+        $this->sleptSeconds[] = $seconds;
+    }
+}

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -3,7 +3,9 @@
 namespace Pantheon\Terminus\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Exceptions\TerminusUnsupportedSiteException;
+use Pantheon\Terminus\Models\SavedToken;
 use Pantheon\Terminus\Request\Request;
 use Pantheon\Terminus\Session\Session;
 use Consolidation\Config\Config;
@@ -20,7 +22,12 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class RequestTest extends TestCase
 {
-    private function createRequest(): FastRequest
+    /**
+     * @param Session|null $session Defaults to a session whose getAuthToken() throws
+     *   (i.e. "no saved token to refresh with"), so 401 tests that don't care about
+     *   refresh behavior get a harmless, single-call-only default.
+     */
+    private function createRequest(?Session $session = null): FastRequest
     {
         $request = new FastRequest();
         $request->setConfig(new Config([
@@ -41,21 +48,53 @@ class RequestTest extends TestCase
         $container->add('input', $input);
         $request->setContainer($container);
 
-        $session = $this->createMock(Session::class);
-        $session->method('get')->willReturn('fake-session-token');
-        $request->setSession($session);
+        $request->setSession($session ?? $this->createSessionMockWithNoAuthToken(['fake-session-token']));
 
         return $request;
     }
 
     /**
-     * Wires up the given queue of responses/exceptions behind the same retry
-     * decider that production code uses, and attaches it to $request.
+     * Builds a Session mock whose get('session') returns each value in
+     * $sessionTokenSequence in order across successive calls, and whose
+     * getAuthToken() returns the given SavedToken (e.g. a mock whose logIn()
+     * either succeeds or throws).
      */
-    private function attachMockHandler(FastRequest $request, array $queue): MockHandler
+    private function createSessionMockWithAuthToken(array $sessionTokenSequence, SavedToken $authToken): Session
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('get')->willReturnOnConsecutiveCalls(...$sessionTokenSequence);
+        $session->method('getAuthToken')->willReturn($authToken);
+        return $session;
+    }
+
+    /**
+     * Builds a Session mock whose get('session') returns each value in
+     * $sessionTokenSequence in order across successive calls, and whose
+     * getAuthToken() throws (i.e. no saved token available to refresh with).
+     */
+    private function createSessionMockWithNoAuthToken(array $sessionTokenSequence): Session
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('get')->willReturnOnConsecutiveCalls(...$sessionTokenSequence);
+        $session->method('getAuthToken')->willThrowException(
+            new TerminusException('You are not logged in. Run `auth:login` to authenticate.')
+        );
+        return $session;
+    }
+
+    /**
+     * Wires up the given queue of responses/exceptions behind the same retry
+     * decider that production code uses, and attaches it to $request. If
+     * $history is given, every request sent through the client is recorded there.
+     */
+    private function attachMockHandler(FastRequest $request, array $queue, ?array &$history = null): MockHandler
     {
         $mockHandler = new MockHandler($queue);
         $stack = HandlerStack::create($mockHandler);
+
+        if ($history !== null) {
+            $stack->push(Middleware::history($history));
+        }
 
         $method = new \ReflectionMethod(Request::class, 'createRetryDecider');
         $method->setAccessible(true);
@@ -104,10 +143,76 @@ class RequestTest extends TestCase
         $this->assertSame(0, $mockHandler->count());
     }
 
-    public function testUnauthorizedIsNotRetried()
+    public function testUnauthorizedWithNoTokenToRefreshWithIsNotRetried()
     {
+        // Default createRequest() session has no saved token: getAuthToken() throws.
         $request = $this->createRequest();
         $mockHandler = $this->attachMockHandler($request, [new Response(401, [], '{}')]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(401, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testUnauthorizedWithFailedRefreshIsNotRetried()
+    {
+        $savedToken = $this->createMock(SavedToken::class);
+        $savedToken->method('logIn')->willThrowException(
+            new TerminusException('Could not log in with the given machine token.')
+        );
+        $session = $this->createSessionMockWithAuthToken(['fake-session-token'], $savedToken);
+
+        $request = $this->createRequest($session);
+        $mockHandler = $this->attachMockHandler($request, [new Response(401, [], '{}')]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(401, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testUnauthorizedRefreshesSessionAndRetriesOnce()
+    {
+        $savedToken = $this->createMock(SavedToken::class);
+        $savedToken->method('logIn')->willReturn(null);
+        $session = $this->createSessionMockWithAuthToken(
+            ['token-before-refresh', 'token-after-refresh'],
+            $savedToken
+        );
+
+        $request = $this->createRequest($session);
+        $history = [];
+        $mockHandler = $this->attachMockHandler($request, [
+            new Response(401, [], '{}'),
+            new Response(200, [], '{}'),
+        ], $history);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+        $this->assertCount(2, $history);
+        $this->assertNotSame(
+            $history[0]['request']->getHeaderLine('Authorization'),
+            $history[1]['request']->getHeaderLine('Authorization')
+        );
+    }
+
+    public function testUnauthorizedRefreshSucceedsButRetryStillFailsIsNotRetriedAgain()
+    {
+        $savedToken = $this->createMock(SavedToken::class);
+        $savedToken->method('logIn')->willReturn(null);
+        $session = $this->createSessionMockWithAuthToken(
+            ['token-before-refresh', 'token-after-refresh'],
+            $savedToken
+        );
+
+        $request = $this->createRequest($session);
+        $mockHandler = $this->attachMockHandler($request, [
+            new Response(401, [], '{}'),
+            new Response(401, [], '{}'),
+        ]);
 
         $result = $request->request('sites');
 

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Exceptions\TerminusUnsupportedSiteException;
+use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\Session\Session;
+use Consolidation\Config\Config;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use League\Container\Container;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Input\InputInterface;
+
+class RequestTest extends TestCase
+{
+    private function createRequest(): FastRequest
+    {
+        $request = new FastRequest();
+        $request->setConfig(new Config([
+            'protocol' => 'https',
+            'host' => 'example.com',
+            'port' => '443',
+            'client_options' => [],
+            'http_max_retries' => 5,
+            'http_retry_backoff' => 3,
+        ]));
+        $request->setLogger(new NullLogger());
+
+        $container = new Container();
+        $input = $this->createMock(InputInterface::class);
+        $input->method('getFirstArgument')->willReturn(null);
+        $input->method('getArguments')->willReturn([]);
+        $input->method('getOptions')->willReturn([]);
+        $container->add('input', $input);
+        $request->setContainer($container);
+
+        $session = $this->createMock(Session::class);
+        $session->method('get')->willReturn('fake-session-token');
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    /**
+     * Wires up the given queue of responses/exceptions behind the same retry
+     * decider that production code uses, and attaches it to $request.
+     */
+    private function attachMockHandler(FastRequest $request, array $queue): MockHandler
+    {
+        $mockHandler = new MockHandler($queue);
+        $stack = HandlerStack::create($mockHandler);
+
+        $method = new \ReflectionMethod(Request::class, 'createRetryDecider');
+        $method->setAccessible(true);
+        $decider = $method->invoke($request);
+        $stack->push(Middleware::retry($decider));
+
+        $client = new Client(['handler' => $stack, 'http_errors' => false]);
+
+        $clientProperty = new \ReflectionProperty(Request::class, 'client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($request, $client);
+
+        return $mockHandler;
+    }
+
+    public function testSuccessfulResponseIsNotRetried()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [new Response(200, [], '{}')]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testNotFoundIsNotRetried()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [new Response(404, [], '{}')]);
+
+        $result = $request->request('sites/does-not-exist');
+
+        $this->assertSame(404, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testForbiddenIsNotRetried()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [new Response(403, [], '{}')]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(403, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testUnauthorizedIsNotRetried()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [new Response(401, [], '{}')]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(401, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+    }
+
+    public function testConflictThrowsUnsupportedSiteException()
+    {
+        $request = $this->createRequest();
+        $this->attachMockHandler($request, [
+            new Response(409, [], json_encode(['message' => 'This is not supported for this site.'])),
+        ]);
+
+        $this->expectException(TerminusUnsupportedSiteException::class);
+        $request->request('sites/unsupported-action');
+    }
+
+    public function testConnectExceptionIsRetriedOnce()
+    {
+        $request = $this->createRequest();
+        $psrRequest = new Psr7Request('GET', 'https://example.com/api/sites');
+        $mockHandler = $this->attachMockHandler($request, [
+            new ConnectException('Connection refused', $psrRequest),
+            new Response(200, [], '{}'),
+        ]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+        $this->assertCount(1, $request->sleptSeconds);
+    }
+
+    public function testRetryableStatusCodeRetriesUntilSuccess()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [
+            new Response(503, [], '{}'),
+            new Response(503, [], '{}'),
+            new Response(200, [], '{}'),
+        ]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+        // Linear backoff: base(3) * (retry + 1).
+        $this->assertSame([3, 6], $request->sleptSeconds);
+    }
+
+    public function testRateLimitedStatusCodeIsRetried()
+    {
+        $request = $this->createRequest();
+        $mockHandler = $this->attachMockHandler($request, [
+            new Response(429, [], '{}'),
+            new Response(429, [], '{}'),
+            new Response(200, [], '{}'),
+        ]);
+
+        $result = $request->request('sites');
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame(0, $mockHandler->count());
+        // Exponential backoff: base(3) * 2^(retry + 1).
+        $this->assertSame([6, 12], $request->sleptSeconds);
+    }
+}

--- a/tests/Unit/RetryPolicyTest.php
+++ b/tests/Unit/RetryPolicyTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Request\RetryPolicy;
+
+class RetryPolicyTest extends TestCase
+{
+    /**
+     * @dataProvider retryableStatusCodeProvider
+     */
+    public function testIsRetryableStatusCode(int $statusCode, bool $expected)
+    {
+        $this->assertSame($expected, RetryPolicy::isRetryableStatusCode($statusCode));
+    }
+
+    public function retryableStatusCodeProvider(): array
+    {
+        return [
+            // Retryable: transient conditions.
+            'request timeout' => [408, true],
+            'rate limited' => [429, true],
+            'internal server error' => [500, true],
+            'bad gateway' => [502, true],
+            'service unavailable' => [503, true],
+            'gateway timeout' => [504, true],
+
+            // Not retryable: success / redirects.
+            'ok' => [200, false],
+            'im used' => [226, false],
+            'multiple choices' => [300, false],
+            'moved permanently' => [301, false],
+
+            // Not retryable: permanent client errors.
+            'bad request' => [400, false],
+            'unauthorized' => [401, false],
+            'forbidden' => [403, false],
+            'not found' => [404, false],
+            'conflict' => [409, false],
+            'gone' => [410, false],
+            'length required' => [411, false],
+            'unprocessable entity' => [422, false],
+            'locked' => [423, false],
+            'too many header fields' => [431, false],
+            'unavailable for legal reasons' => [451, false],
+
+            // Not retryable: permanent server-side failures.
+            'not implemented' => [501, false],
+            'http version not supported' => [505, false],
+            'variant also negotiates' => [506, false],
+            'loop detected' => [508, false],
+            'network authentication required' => [511, false],
+        ];
+    }
+
+    public function testIsRateLimit()
+    {
+        $this->assertTrue(RetryPolicy::isRateLimit(429));
+
+        foreach ([408, 500, 502, 503, 504, 200, 401, 403] as $statusCode) {
+            $this->assertFalse(RetryPolicy::isRateLimit($statusCode));
+        }
+    }
+
+    /**
+     * @dataProvider backoffSecondsProvider
+     */
+    public function testBackoffSeconds(int $statusCode, int $retryBackoff, int $retry, int $expected)
+    {
+        $this->assertSame($expected, RetryPolicy::backoffSeconds($statusCode, $retryBackoff, $retry));
+    }
+
+    public function backoffSecondsProvider(): array
+    {
+        return [
+            // Non-rate-limit codes keep the existing linear backoff: base * (retry + 1).
+            'linear, first retry' => [503, 3, 0, 3],
+            'linear, second retry' => [503, 3, 1, 6],
+            'linear, third retry' => [503, 3, 2, 9],
+            'linear, different base' => [500, 5, 3, 20],
+
+            // 429 backs off exponentially: base * 2^(retry + 1).
+            'rate limit, first retry' => [429, 3, 0, 6],
+            'rate limit, second retry' => [429, 3, 1, 12],
+            'rate limit, third retry' => [429, 3, 2, 24],
+            'rate limit, different base' => [429, 5, 3, 80],
+        ];
+    }
+}

--- a/tests/Unit/RetryPolicyTest.php
+++ b/tests/Unit/RetryPolicyTest.php
@@ -19,7 +19,6 @@ class RetryPolicyTest extends TestCase
     {
         return [
             // Retryable: transient conditions.
-            'request timeout' => [408, true],
             'rate limited' => [429, true],
             'internal server error' => [500, true],
             'bad gateway' => [502, true],
@@ -31,6 +30,9 @@ class RetryPolicyTest extends TestCase
             'im used' => [226, false],
             'multiple choices' => [300, false],
             'moved permanently' => [301, false],
+
+            // Not retryable: might not be idempotent
+            'request timeout' => [408, false],
 
             // Not retryable: permanent client errors.
             'bad request' => [400, false],

--- a/tests/Unit/SavedTokenTest.php
+++ b/tests/Unit/SavedTokenTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Models\SavedToken;
+use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\Request\RequestOperationResult;
+use Pantheon\Terminus\Session\Session;
+
+class SavedTokenTest extends TestCase
+{
+    private function createSavedToken(Request $request, Session $session): SavedToken
+    {
+        $token = new SavedToken((object)['token' => 'fake-machine-token']);
+        $token->setRequest($request);
+        $token->setSession($session);
+        return $token;
+    }
+
+    public function testLogInThrowsOnNonSuccessfulResponse()
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('requestWithoutRefreshHandling')->willReturn(
+            new RequestOperationResult([
+                'data' => (object)['message' => 'invalid machine token'],
+                'headers' => [],
+                'status_code' => 401,
+                'status_code_reason' => 'Unauthorized',
+            ])
+        );
+        $session = $this->createMock(Session::class);
+        $session->expects($this->never())->method('setData');
+
+        $token = $this->createSavedToken($request, $session);
+
+        $this->expectException(TerminusException::class);
+        $token->logIn();
+    }
+
+    public function testLogInSucceedsOnSuccessfulResponse()
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('requestWithoutRefreshHandling')->willReturn(
+            new RequestOperationResult([
+                'data' => (object)['session' => 'new-session-token', 'user_id' => 'user-123'],
+                'headers' => [],
+                'status_code' => 200,
+                'status_code_reason' => 'OK',
+            ])
+        );
+
+        $session = $this->createMock(Session::class);
+        $session->expects($this->once())->method('setData')->with([
+            'session' => 'new-session-token',
+            'user_id' => 'user-123',
+        ]);
+        $user = $this->createMock(User::class);
+        $session->method('getUser')->willReturn($user);
+
+        $token = $this->createSavedToken($request, $session);
+
+        $this->assertSame($user, $token->logIn());
+    }
+}

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Collections\SavedTokens;
+use Pantheon\Terminus\DataStore\DataStoreInterface;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Models\SavedToken;
+use Pantheon\Terminus\Session\Session;
+use Consolidation\Config\Config;
+
+class SessionTest extends TestCase
+{
+    private function createSession(SavedTokens $tokens, array $configValues = []): Session
+    {
+        $dataStore = $this->createMock(DataStoreInterface::class);
+        $dataStore->method('get')->willReturn([]);
+
+        $session = new Session($dataStore);
+        $session->setConfig(new Config($configValues));
+        // SavedTokens::$tokens is public; Session::getTokens() uses it directly
+        // if already set, so this avoids needing a real container/collection.
+        $session->tokens = $tokens;
+
+        return $session;
+    }
+
+    public function testGetAuthTokenWithSingleSavedToken()
+    {
+        $token = $this->createMock(SavedToken::class);
+        $tokens = $this->createMock(SavedTokens::class);
+        $tokens->method('all')->willReturn(['someone@example.com' => $token]);
+
+        $session = $this->createSession($tokens);
+
+        $this->assertSame($token, $session->getAuthToken());
+    }
+
+    public function testGetAuthTokenWithConfiguredUserEmail()
+    {
+        $matchingToken = $this->createMock(SavedToken::class);
+        $otherToken = $this->createMock(SavedToken::class);
+        $tokens = $this->createMock(SavedTokens::class);
+        $tokens->method('all')->willReturn([
+            'someone@example.com' => $otherToken,
+            'match@example.com' => $matchingToken,
+        ]);
+        $tokens->method('get')->with('match@example.com')->willReturn($matchingToken);
+
+        $session = $this->createSession($tokens, ['user' => 'match@example.com']);
+
+        $this->assertSame($matchingToken, $session->getAuthToken());
+    }
+
+    public function testGetAuthTokenWithMultipleTokensAndNoConfiguredUserThrows()
+    {
+        $tokens = $this->createMock(SavedTokens::class);
+        $tokens->method('all')->willReturn([
+            'someone@example.com' => $this->createMock(SavedToken::class),
+            'someone-else@example.com' => $this->createMock(SavedToken::class),
+        ]);
+
+        $session = $this->createSession($tokens);
+
+        $this->expectException(TerminusException::class);
+        $session->getAuthToken();
+    }
+}


### PR DESCRIPTION
This investigation started with a report from Claude that Terminus does not retry requests when a failure is caused from an expired token, leading to some concern that there may be problems when we decrease the session TTL from about a day to about 15 minutes. If a command, e.g. a workflow takes longer than the TTL to run, then the session will not be refreshed and the command will fail.

This PR adjusts the `$request->request()` function to automatically refresh the session token when a 401 is received. A small refactoring is done so that 401's received during the refresh request do not cause an infinite automatic refresh. 

During this work, some logic problems in the way that Terminus handles HTTP status headers was revealed. Some failed requests that should not be retried were retried, and vis-versa.

Request::createRetryDecider() excluded codes from retry via preg_match('/[2,4]0\d/', $statusCode), commented as "do not retry on 20x or 40x responses." The regex only matches when the first digit is 2 or 4 and the second digit is literally 0, so it actually only excludes 200-209 and 400-409 - every other code fell through and was retried regardless of whether that made sense. Replaced with an explicit RetryPolicy allow-list (408, 429, 500, 502, 503, 504) and documented why the rest are excluded. Also gives 429 (rate limit) its own exponential backoff instead of the linear backoff used for other retryable codes, since a fixed/linear delay is unlikely to clear a rate limit in time.

401 is intentionally left non-retryable: Terminus already refreshes the session proactively before every command (Authorizer::ensureLogin()), so a 401 that still occurs means the credentials are invalid/revoked and retrying won't help most of the time. We'll consider handling situations where tokens expire or are refreshed mid-command as follow-on work.

Status codes whose retry behavior changes:
- ~Now retried, previously was not (bug fix): 408 Request Timeout~
- No longer retried, previously was (bug fix, since these are permanent client/server errors that retrying cannot fix): 210-299 (e.g. 226), all 3xx redirects, 410 Gone, 411 Length Required, 412 Precondition Failed, 413 Payload Too Large, 414 URI Too Long, 415 Unsupported Media Type, 416 Range Not Satisfiable, 417 Expectation Failed, 418 I'm a Teapot, 421 Misdirected Request, 422 Unprocessable Entity, 423 Locked, 424 Failed Dependency, 425 Too Early, 426 Upgrade Required, 428 Precondition Required, 431 Request Header Fields Too Large, 451 Unavailable For Legal Reasons, 501 Not Implemented, 505 HTTP Version Not Supported, 506 Variant Also Negotiates, 507 Insufficient Storage, 508 Loop Detected, 510 Not Extended, 511 Network Authentication Required
- Still retried, but backoff changes from linear to exponential: 429 Too Many Requests
- Unchanged (still retried): 500, 502, 503, 504
- Unchanged (still not retried, now explicit instead of incidental): 401 Unauthorized, 403 Forbidden, *408 Request Timeout*